### PR TITLE
Fix export to vtk

### DIFF
--- a/gempy/plot/visualization_3d.py
+++ b/gempy/plot/visualization_3d.py
@@ -1177,7 +1177,7 @@ class vtkVisualization(object):
 
         if lith_block is None:
             lith_block = geo_data.solutions.lith_block
-        lith = lith_block.reshape((nx, ny, nz))
+        lith = lith_block.reshape((nx, ny, nz)).flatten(order='F')
         out = pv.RectilinearGrid(x,y,z)
         out['Lithology'] = lith
         out.save(path+'_lith_block.vtr')


### PR DESCRIPTION
# Description

A small change that solves issue #641 that was causing a bug while exporting a model to vtk via `Pyvista`.
The `Pyvista` receives a flatten array but the `gempy` passed 3D array of lithology to set values to mesh cells.

As only a single line was changed I don't know if I have to check boxes in the checklists below, so I leave them unchecked for now. 

# Checklist
- [ ] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [ ] I have created tests which entirely cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New and existing tests pass locally with my changes.
 
