### PR TITLE
[BUG] ColorsGenerator never returns random_colors

### DIFF
--- a/test/test_core/test_color_generator.py
+++ b/test/test_core/test_color_generator.py
@@ -1,10 +1,10 @@
-﻿from gempy.core.color_generator import ColorsGenerator
+import gempy.core.color_generator as cg
 
 
 def test_color_generator():
 
     # create an instance of ColorsGenerator
-    color_iterator: iter = ColorsGenerator()
+    color_iterator: iter = cg.ColorsGenerator()
 
     # generate color dictionary (with optional seaborn palettes if you want)
 
@@ -13,4 +13,32 @@ def test_color_generator():
     # now you can get colors one by one
     print(next(color_iterator))  # prints first color
     print(next(color_iterator))  # prints second color
+
+    left_colors = color_iterator._gempy_default_colors[2:]
+
+    assert left_colors == [
+        color for color, _ in zip(color_iterator, left_colors)
+    ]
+
+    # get a random color
+    assert color_iterator.up_next() == next(color_iterator)
+
+    # override the random color generator
+    cg.np.random.randint = lambda a, b: 0x00ff42
+
+    assert color_iterator._random_hexcolor() == "#00ff42"
+    assert next(color_iterator) == "#00ff42"
+
+    # trigger up_next method for the cache
+    assert color_iterator.up_next() == "#00ff42"
+
+    cg.np.random.randint = lambda a, b: 0x000000
+
+    # ensure that the up_next method still returns the same color
+    assert color_iterator.up_next() == "#00ff42"
+
+    # trigger the cache
+    assert next(color_iterator) == "#00ff42"
+    assert next(color_iterator) == "#000000"
+
     # etc...


### PR DESCRIPTION
# Description

 - Use random colors when no more `hex_color`.
 - Ensure that the `up_next` method is consistent with `__next__` when using random colors.
 - Fix issue with `_random_hexcolor`, happening once every 16 calls where you end up with less than 6 numbers after the `#`, because of how [lstrip](https://docs.python.org/3/library/stdtypes.html#str.lstrip) works.
 - Add tests for each points mentioned above.

Relates to #930 

# Checklist
- [x] My code follows the [PEP 8 style guidelines](https://www.python.org/dev/peps/pep-0008/).
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] My code contains descriptive and helpful docstrings 
which are formatted per the [Google Python Style Guidelines](http://google.github.io/styleguide/pyguide.html).
- [x] I have created tests which entirely cover my code.
- [x] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [x] New and existing tests pass locally with my changes.
 
