### PR TITLE
[ENH] Fix color generator initialization and improve basement color handling

### DIFF
--- a/gempy/core/color_generator.py
+++ b/gempy/core/color_generator.py
@@ -35,7 +35,7 @@ class ColorsGenerator:
     )
     _index: int = 0
 
-    def __init__(self):
+    def __post_init__(self):
         self.regenerate_color_palette()
 
     @staticmethod

--- a/gempy/core/data/structural_frame.py
+++ b/gempy/core/data/structural_frame.py
@@ -3,7 +3,7 @@
 import numpy as np
 import warnings
 from dataclasses import dataclass
-from pydantic import model_validator, computed_field, ValidationError
+from pydantic import model_validator, computed_field, ValidationError, Field
 from pydantic.functional_validators import ModelWrapValidatorHandler
 from typing import Generator, Union
 
@@ -32,11 +32,12 @@ class StructuralFrame:
     """
 
     structural_groups: list[StructuralGroup]
+    color_generator: ColorsGenerator =  Field(default_factory=ColorsGenerator)
     # ? Should I create some sort of structural options class? For example, the masking descriptor and faults relations pointer
     is_dirty: bool = True
 
     # region Constructor
-
+    # 
     def __init__(self, structural_groups: list[StructuralGroup], color_gen: ColorsGenerator):
         self.structural_groups = structural_groups  # ? This maybe could be optional
         self.color_generator = color_gen

--- a/gempy/modules/optimize_nuggets/_ops.py
+++ b/gempy/modules/optimize_nuggets/_ops.py
@@ -43,7 +43,9 @@ def run_optimization(lr, max_epochs, min_impr, model, nugget, patience, target_c
         if _has_converged(cur_cond, prev_cond, target_cond_num, epoch, min_impr, patience):
             break
         prev_cond = cur_cond
-        
+
+    # Condition number to numpy
+    model.interpolation_options.kernel_options.condition_number = model.interpolation_options.kernel_options.condition_number.detach().numpy()
     return nugget
 
 

--- a/gempy/modules/serialization/save_load.py
+++ b/gempy/modules/serialization/save_load.py
@@ -169,7 +169,6 @@ def model_to_bytes(model: GeoModel) -> bytes:
     return buf.getvalue()
 
 def _load_model_from_bytes(data: bytes) -> GeoModel:
-    import json, zlib
     from ...core.data.encoders.converters import loading_model_from_binary
 
     buf = io.BytesIO(data)

--- a/test/test_modules/_geophysics_TO_UPDATE/test_gravity.test_gravity.verify/2-layers.approved.txt
+++ b/test/test_modules/_geophysics_TO_UPDATE/test_gravity.test_gravity.verify/2-layers.approved.txt
@@ -53,8 +53,11 @@
                 "solution": null
             }
         ],
-        "is_dirty": true,
+        "color_generator": {
+            "_index": 3
+        },
         "basement_color": "#ffbe00",
+        "is_dirty": true,
         "binary_meta_data": {
             "sp_binary_length": 144,
             "ori_binary_length": 60

--- a/test/test_modules/test_faults/test_finite_faults.test_finite_fault_scalar_field_on_fault.verify/fault.approved.txt
+++ b/test/test_modules/test_faults/test_finite_faults.test_finite_fault_scalar_field_on_fault.verify/fault.approved.txt
@@ -127,8 +127,11 @@
                 "solution": null
             }
         ],
-        "is_dirty": true,
+        "color_generator": {
+            "_index": 4
+        },
         "basement_color": "#728f02",
+        "is_dirty": true,
         "binary_meta_data": {
             "sp_binary_length": 792,
             "ori_binary_length": 300

--- a/test/test_modules/test_grids/test_custom_grid.test_custom_grid.verify/fold.approved.txt
+++ b/test/test_modules/test_grids/test_custom_grid.test_custom_grid.verify/fold.approved.txt
@@ -59,8 +59,11 @@
                 "solution": null
             }
         ],
-        "is_dirty": true,
+        "color_generator": {
+            "_index": 3
+        },
         "basement_color": "#ffbe00",
+        "is_dirty": true,
         "binary_meta_data": {
             "sp_binary_length": 1296,
             "ori_binary_length": 120

--- a/test/test_modules/test_grids/test_grids_sections.test_section_grids.verify/fold.approved.txt
+++ b/test/test_modules/test_grids/test_grids_sections.test_section_grids.verify/fold.approved.txt
@@ -59,8 +59,11 @@
                 "solution": null
             }
         ],
-        "is_dirty": true,
+        "color_generator": {
+            "_index": 3
+        },
         "basement_color": "#ffbe00",
+        "is_dirty": true,
         "binary_meta_data": {
             "sp_binary_length": 1296,
             "ori_binary_length": 120

--- a/test/test_modules/test_grids/test_grids_sections.test_topography_II.verify/Model1.approved.txt
+++ b/test/test_modules/test_grids/test_grids_sections.test_topography_II.verify/Model1.approved.txt
@@ -13,7 +13,7 @@
                     {
                         "name": "fault1",
                         "is_active": true,
-                        "_color": "#728f02",
+                        "_color": "#443988",
                         "surface_points": {
                             "name_id_map": {
                                 "fault1": 26244822
@@ -56,7 +56,7 @@
                     {
                         "name": "surface2",
                         "is_active": true,
-                        "_color": "#9f0052",
+                        "_color": "#ffbe00",
                         "surface_points": {
                             "name_id_map": {
                                 "surface2": 21816406
@@ -73,7 +73,7 @@
                     {
                         "name": "surface3",
                         "is_active": true,
-                        "_color": "#ffbe00",
+                        "_color": "#728f02",
                         "surface_points": {
                             "name_id_map": {
                                 "surface3": 98435767
@@ -94,8 +94,11 @@
                 "solution": null
             }
         ],
+        "color_generator": {
+            "_index": 5
+        },
+        "basement_color": "#9f0052",
         "is_dirty": true,
-        "basement_color": "#443988",
         "binary_meta_data": {
             "sp_binary_length": 360,
             "ori_binary_length": 120

--- a/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
+++ b/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
@@ -59,8 +59,11 @@
                 "solution": null
             }
         ],
-        "is_dirty": true,
+        "color_generator": {
+            "_index": 2
+        },
         "basement_color": "#ffbe00",
+        "is_dirty": true,
         "binary_meta_data": {
             "sp_binary_length": 432,
             "ori_binary_length": 120

--- a/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
+++ b/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
@@ -60,7 +60,7 @@
             }
         ],
         "color_generator": {
-            "_index": 2
+            "_index": 3
         },
         "basement_color": "#ffbe00",
         "is_dirty": true,

--- a/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
+++ b/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
@@ -61,8 +61,10 @@ def test_optimize_nugget_effect():
         engine_config=gp.data.GemPyEngineConfig(
             backend=gp.data.AvailableBackends.PYTORCH,
         ),
-        validate_serialization=False
+        validate_serialization=True
     )
+    
+    # TODO: Save model
 
     print(f"Final cond number: {geo_model.interpolation_options.kernel_options.condition_number}")
     nugget_effect = geo_model.taped_interpolation_input.surface_points.nugget_effect_scalar.detach().numpy()

--- a/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
+++ b/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
@@ -64,8 +64,6 @@ def test_optimize_nugget_effect():
         validate_serialization=True
     )
     
-    # TODO: Save model
-
     print(f"Final cond number: {geo_model.interpolation_options.kernel_options.condition_number}")
     nugget_effect = geo_model.taped_interpolation_input.surface_points.nugget_effect_scalar.detach().numpy()
 


### PR DESCRIPTION
# Description
This PR refactors the `ColorsGenerator` class to use `__post_init__` instead of `__init__` and improves the basement color generation in `StructuralFrame`. The changes include:

- Refactored `ColorsGenerator` to use `__post_init__` for proper dataclass initialization
- Added `color_generator` as a proper field with default factory in `StructuralFrame`
- Improved basement color generation logic to ensure uniqueness
- Fixed a tensor detachment issue in nugget optimization by converting to numpy
- Removed unused imports in serialization and test modules
- Updated test validation settings

Relates to #optimization-and-refactoring

# Checklist
- [x] My code uses type hinting for function and method arguments and return values.
- [x] I have created tests which cover my code.
- [x] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [x] New tests pass locally with my changes.