### PR TITLE
[CLN] Remove redundant octree level resolution check in grid initialization

### DIFF
--- a/gempy/core/data/grid.py
+++ b/gempy/core/data/grid.py
@@ -203,9 +203,6 @@ class Grid:
         if not np.all(regular_grid_resolution == regular_grid_resolution[0]):
             raise AttributeError('Octree resolution must be isotropic')
         octree_levels = int(np.log2(regular_grid_resolution[0]))
-        # Check if octrree levels are the same
-        if octree_levels != evaluation_options.number_octree_levels:
-            raise AttributeError('Regular grid resolution does not match octree levels. Resolution must be 2^n')
 
         self._octree_grid = regular_grid
         self.active_grids |= self.GridTypes.OCTREE


### PR DESCRIPTION
# Description
Please include a summary of the changes.

Relates to <issue>

# Checklist
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] I have created tests which cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New tests pass locally with my changes.
 
