### PR TITLE
[ENH] Add name_id_map parameter to add_orientations and enable serialization validation

### DIFF
--- a/examples/examples/real/Hecho.py
+++ b/examples/examples/real/Hecho.py
@@ -127,7 +127,7 @@ geo_model: gp.data.GeoModel = gp.create_geomodel(
 gp.set_section_grid(
     grid=geo_model.grid,
     section_dict={
-            'section': ([0, 0], [16, 0], [321, 91])
+            'section': ((0., 0.), (16., 0.), (321, 91))
     },
 )
 
@@ -218,10 +218,6 @@ geo_model.interpolation_options.kernel_options.range *= 0.2
 # Setting verbose and condition number options for debugging
 geo_model.interpolation_options.kernel_options.compute_condition_number = True
 
-gp.save_model(geo_model, 'Hecho.gempy')
-model_deserialized = gp.load_model('Hecho.gempy')
-
-_validate_serialization(geo_model, model_deserialized)
 
 # %% 
 gp.compute_model(
@@ -230,7 +226,7 @@ gp.compute_model(
         backend=gp.data.AvailableBackends.PYTORCH,
         dtype='float64'
     ),
-    validate_serialization=False
+    validate_serialization=True
 )
 
 # %% 

--- a/examples/examples/real/Hecho.py
+++ b/examples/examples/real/Hecho.py
@@ -12,6 +12,7 @@ import numpy as np
 
 # Aux imports
 import pandas as pn
+from gempy.modules.serialization.save_load import _validate_serialization
 
 # Importing gempy
 import gempy as gp
@@ -149,7 +150,8 @@ for fn in f_names:
         y=new_orientations.data['Y'],
         z=new_orientations.data['Z'],
         pole_vector=new_orientations.grads,
-        elements_names=fn
+        elements_names=fn,
+        name_id_map=element.surface_points.name_id_map 
     )
 
 # %%
@@ -215,6 +217,11 @@ geo_model.interpolation_options.kernel_options.range *= 0.2
 # %%
 # Setting verbose and condition number options for debugging
 geo_model.interpolation_options.kernel_options.compute_condition_number = True
+
+gp.save_model(geo_model, 'Hecho.gempy')
+model_deserialized = gp.load_model('Hecho.gempy')
+
+_validate_serialization(geo_model, model_deserialized)
 
 # %% 
 gp.compute_model(

--- a/gempy/modules/data_manipulation/manipulate_points.py
+++ b/gempy/modules/data_manipulation/manipulate_points.py
@@ -96,7 +96,8 @@ def add_orientations(geo_model: GeoModel,
         elements_names: Sequence[str],
         pole_vector: Optional[Union[Sequence[np.ndarray], np.ndarray]] = None,
         orientation: Optional[Union[Sequence[np.ndarray], np.ndarray]] = None,
-        nugget: Optional[Sequence[float]] = None
+        nugget: Optional[Sequence[float]] = None,
+        name_id_map: Optional[dict[str, int]] = None  #: A mapping between orientation names and ids.
 ) -> StructuralFrame:
     """Add orientation data to the geological model.
 
@@ -176,6 +177,7 @@ def add_orientations(geo_model: GeoModel,
             G_z=data['pole_vector'][..., 2],
             names=[element_name] * len(data['x']),
             nugget=data['nugget'],
+            name_id_map=name_id_map
         )
 
         element: StructuralElement = geo_model.structural_frame.get_element_by_name(element_name)


### PR DESCRIPTION
# Description
Added support for name_id_map parameter in add_orientations function to maintain consistent ID mapping between surface points and orientations. Updated the Hecho example to use this parameter and fixed tuple formatting in section_dict. Also enabled validation during serialization in the compute_model call.

Relates to #validation-and-serialization-improvements

# Checklist
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] I have created tests which cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New tests pass locally with my changes.