### PR TITLE
Mapping formations to `surface_points_copy` and `orientations` DataFrames

### DIFF
--- a/gempy/core/data/orientations.py
+++ b/gempy/core/data/orientations.py
@@ -21,11 +21,11 @@ class OrientationsTable:
     
     """
 
-    dt = np.dtype([('X', 'f8'), ('Y', 'f8'), ('Z', 'f8'), ('G_x', 'f8'), ('G_y', 'f8'), ('G_z', 'f8'), ('id', 'i4'), ('nugget', 'f8')])  #: The custom data type for the data array.
+    dt = np.dtype([('X', 'f8'), ('Y', 'f8'), ('Z', 'f8'), ('G_x', 'f8'), ('G_y', 'f8'), ('G_z', 'f8'), ('id', 'i4'), ('nugget', 'f8'), ('formation', 'U20')])  #: The custom data type for the data array.
     data: np.ndarray = Field(
         default=np.zeros(0, dtype=dt),
         exclude=True,
-        description="A structured NumPy array holding the X, Y, Z coordinates, gradients G_x, G_y, G_z, id, and nugget of each orientation.",
+        description="A structured NumPy array holding the X, Y, Z coordinates, gradients G_x, G_y, G_z, id, nugget and formation of each orientation.",
     )  #: A structured NumPy array holding the X, Y, Z coordinates, id, and nugget of each surface point.
     name_id_map: Optional[dict[str, int]] = None  #: A mapping between orientation names and ids.
 
@@ -73,7 +73,7 @@ class OrientationsTable:
         else:
             ids = np.array([name_id_map[name] for name in names])
         data = np.zeros(len(x), dtype=OrientationsTable.dt)
-        data['X'], data['Y'], data['Z'], data['G_x'], data['G_y'], data['G_z'], data['id'], data['nugget'] = x, y, z, G_x, G_y, G_z, ids, nugget
+        data['X'], data['Y'], data['Z'], data['G_x'], data['G_y'], data['G_z'], data['id'], data['nugget'], data['formation'] = x, y, z, G_x, G_y, G_z, ids, nugget, names
         return data, name_id_map
 
     @classmethod
@@ -142,6 +142,10 @@ class OrientationsTable:
             np.ndarray: The nugget values.
         """
         return self.data['nugget']
+
+    @property
+    def formation(self) -> np.ndarray:
+        return self.data['formation']
 
     @property
     def ids(self) -> np.ndarray:

--- a/gempy/core/data/structural_frame.py
+++ b/gempy/core/data/structural_frame.py
@@ -59,7 +59,7 @@ class StructuralFrame:
                 orientation_i = OrientationsTable.empty_orientation(id_)
 
             structural_element: StructuralElement = StructuralElement(
-                name=surface_points.id_to_name(i),
+                name=surface_points.id_to_name(surface_points_groups[i].df['id'].unique()),
                 id=id_,
                 surface_points=surface_points_groups[i],
                 orientations=orientation_i,

--- a/gempy/core/data/surface_points.py
+++ b/gempy/core/data/surface_points.py
@@ -22,12 +22,12 @@ class SurfacePointsTable:
     A dataclass to represent a table of surface points in a geological model.
     
     """
-    dt = np.dtype([('X', 'f8'), ('Y', 'f8'), ('Z', 'f8'), ('id', 'i4'), ('nugget', 'f8')])  #: The custom data type for the data array.
+    dt = np.dtype([('X', 'f8'), ('Y', 'f8'), ('Z', 'f8'), ('id', 'i4'), ('nugget', 'f8'), ('formation', 'U20')])  #: The custom data type for the data array.
     
     data: np.ndarray = Field(
         default=np.zeros(0, dtype=dt),
         exclude=True,
-        description="A structured NumPy array holding the X, Y, Z coordinates, id, and nugget of each surface point."
+        description="A structured NumPy array holding the X, Y, Z coordinates, id, nugget and formation of each surface point."
     )  #: A structured NumPy array holding the X, Y, Z coordinates, id, and nugget of each surface point.
     name_id_map: Optional[dict[str, int]] = None  #: A mapping between surface point names and ids.
     _model_transform: Optional[Transform] = None
@@ -94,7 +94,7 @@ class SurfacePointsTable:
             ids = np.array([name_id_map[name] for name in names])
 
         data = np.zeros(len(x), dtype=SurfacePointsTable.dt)
-        data['X'], data['Y'], data['Z'], data['id'], data['nugget'] = x, y, z, ids, nugget
+        data['X'], data['Y'], data['Z'], data['id'], data['nugget'], data['formation'] = x, y, z, ids, nugget, names
         return data, name_id_map
 
     @classmethod
@@ -115,7 +115,8 @@ class SurfacePointsTable:
         Returns:
             str: The name of the surface point.
         """
-        return list(self.name_id_map.keys())[id]
+        #list(self.name_id_map.keys())[id]
+        return [key for key, value in self.name_id_map.items() if value == 	id][0]
 
     @property
     def xyz(self) -> np.ndarray:
@@ -136,6 +137,10 @@ class SurfacePointsTable:
     @nugget.setter
     def nugget(self, value: np.ndarray):
         self.data['nugget'] = value
+
+    @property
+    def formation(self) -> np.ndarray:
+        return self.data['formation']
 
     @property
     def model_transform(self) -> Transform:

--- a/gempy/core/data/surface_points.py
+++ b/gempy/core/data/surface_points.py
@@ -115,7 +115,6 @@ class SurfacePointsTable:
         Returns:
             str: The name of the surface point.
         """
-
         return [key for key, value in self.name_id_map.items() if value == 	id][0]
 
     @property

--- a/gempy/core/data/surface_points.py
+++ b/gempy/core/data/surface_points.py
@@ -115,7 +115,7 @@ class SurfacePointsTable:
         Returns:
             str: The name of the surface point.
         """
-        #list(self.name_id_map.keys())[id]
+
         return [key for key, value in self.name_id_map.items() if value == 	id][0]
 
     @property

--- a/test/test_core/test_data/test_orientations.py
+++ b/test/test_core/test_data/test_orientations.py
@@ -1,0 +1,7 @@
+from gempy.core.data import GeoModel
+from test.test_api.test_initialization_and_compute_api import _create_data
+
+def test_surface_points_copy_df():
+    geo_data: GeoModel = _create_data()
+
+    assert list(geo_data.structural_frame.surface_points_copy.df.columns) == ['X', 'Y', 'Z', 'id', 'nugget', 'formation']

--- a/test/test_core/test_data/test_surface_points.py
+++ b/test/test_core/test_data/test_surface_points.py
@@ -1,4 +1,3 @@
-from gempy.core.data import surface_points
 from gempy.core.data import GeoModel
 from test.test_api.test_initialization_and_compute_api import _create_data
 
@@ -10,3 +9,9 @@ def test_id_to_name():
 
     assert geo_data.structural_frame.surface_points_copy.id_to_name(id_number1) == 'rock1'
     assert geo_data.structural_frame.surface_points_copy.id_to_name(id_number2) == 'rock2'
+
+
+def test_surface_points_copy_df():
+    geo_data: GeoModel = _create_data()
+
+    assert list(geo_data.structural_frame.surface_points_copy.df.columns) == ['X', 'Y', 'Z', 'id', 'nugget', 'formation']

--- a/test/test_core/test_data/test_surface_points.py
+++ b/test/test_core/test_data/test_surface_points.py
@@ -1,0 +1,12 @@
+from gempy.core.data import surface_points
+from gempy.core.data import GeoModel
+from test.test_api.test_initialization_and_compute_api import _create_data
+
+def test_id_to_name():
+    geo_data: GeoModel = _create_data()
+
+    id_number1 = geo_data.structural_frame.surface_points_copy.df['id'].unique()[0]
+    id_number2 = geo_data.structural_frame.surface_points_copy.df['id'].unique()[1]
+
+    assert geo_data.structural_frame.surface_points_copy.id_to_name(id_number1) == 'rock1'
+    assert geo_data.structural_frame.surface_points_copy.id_to_name(id_number2) == 'rock2'


### PR DESCRIPTION
# Description
This PR maps the formation according to its ID to each surface point and orientation since this information is currently not available. Further, the `id_to_name` function was fixed to actually take an ID from the surface points DataFrame and return the corresponding formation name. Previously, the index was taken, not the ID of the formation. A corresponding function in `structural_frame.py` was adapted

Relates to #1063 

# Checklist
- [x] My code uses type hinting for function and method arguments and return values.
- [x] I have created tests which cover my code.
- [x] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [x] New tests pass locally with my changes.
 
