### PR TITLE
[CLN] Replace outputs_centers with outputs in octree access patterns

### DIFF
--- a/gempy/API/gp2_gp3_compatibility/gp3_to_gp2_output.py
+++ b/gempy/API/gp2_gp3_compatibility/gp3_to_gp2_output.py
@@ -55,7 +55,7 @@ def _set_surfaces_meshes(geo_model: Project, meshes: list[DualContouringMesh]) -
 def _set_block_matrix(geo_model: Project, octree_output: OctreeLevel) -> Project:
     temp_list = []
     for i in range(octree_output.number_of_outputs):
-        temp_list.append(octree_output.outputs_centers[i].values_block)
+        temp_list.append(octree_output.outputs[i].values_block)
 
     block_matrix_stacked = np.vstack(temp_list)
     geo_model.solutions.block_matrix = block_matrix_stacked
@@ -65,7 +65,7 @@ def _set_block_matrix(geo_model: Project, octree_output: OctreeLevel) -> Project
 def _set_scalar_field(geo_model: Project, octree_output: OctreeLevel) -> Project:
     temp_list = []
     for i in range(octree_output.number_of_outputs):
-        temp_list.append(octree_output.outputs_centers[i].scalar_fields.exported_fields.scalar_field)
+        temp_list.append(octree_output.outputs[i].scalar_fields.exported_fields.scalar_field)
 
     scalar_field_stacked = np.vstack(temp_list)
     geo_model.solutions.scalar_field_matrix = scalar_field_stacked
@@ -75,7 +75,7 @@ def _set_scalar_field(geo_model: Project, octree_output: OctreeLevel) -> Project
 def _set_scalar_field_at_surface_points(geo_model: Project, octree_output: OctreeLevel) -> Project:
     temp_list = []
     for i in range(octree_output.number_of_outputs):
-        temp_list.append(octree_output.outputs_centers[i].scalar_fields.exported_fields.scalar_field_at_surface_points)
+        temp_list.append(octree_output.outputs[i].scalar_fields.exported_fields.scalar_field_at_surface_points)
     
     geo_model.solutions.scalar_field_at_surface_points = temp_list
     return geo_model

--- a/gempy/modules/data_manipulation/_engine_factory.py
+++ b/gempy/modules/data_manipulation/_engine_factory.py
@@ -44,7 +44,7 @@ def interpolation_input_from_structural_frame(geo_model: "gempy.data.GeoModel") 
 
     weights = []
     if geo_model.solutions is not None:
-        for stack_sol in geo_model.solutions.root_output.outputs_centers:
+        for stack_sol in geo_model.solutions.root_output.outputs:
             weights.append(stack_sol.weights)
 
     interpolation_input: InterpolationInput = InterpolationInput(

--- a/gempy/modules/mesh_extranction/marching_cubes.py
+++ b/gempy/modules/mesh_extranction/marching_cubes.py
@@ -30,10 +30,10 @@ def set_meshes_with_marching_cubes(model: GeoModel) -> None:
     regular_grid: RegularGrid = model.grid.regular_grid
     structural_groups: list[StructuralGroup] = model.structural_frame.structural_groups
 
-    if not model.solutions.octrees_output or not model.solutions.octrees_output[0].outputs_centers:
+    if not model.solutions.octrees_output or not model.solutions.octrees_output[0].outputs:
         raise ValueError("No interpolation outputs available for mesh extraction.")
 
-    output_lvl0: list[InterpOutput] = model.solutions.octrees_output[0].outputs_centers
+    output_lvl0: list[InterpOutput] = model.solutions.octrees_output[0].outputs
 
     for e, structural_group in enumerate(structural_groups):
         if e >= len(output_lvl0):

--- a/test/test_model_types/test_example_models_I.py
+++ b/test/test_model_types/test_example_models_I.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.skipif(TEST_SPEED.value < TestSpeed.MINUTES.value, reas
 
 
 def _verify_scalar_field(model, name):
-    outputs_centers_: InterpOutput = model.solutions.octrees_output[-1].outputs_centers[0]
+    outputs_centers_: InterpOutput = model.solutions.octrees_output[-1].outputs[0]
     scalar_field = outputs_centers_.exported_fields.scalar_field
     scalar_field = scalar_field[::int(len(scalar_field) / 50)]  # Pick 50 values from the scalar field array
     gempy_verify_array(scalar_field, name)

--- a/test/test_modules/test_cg/test_cg_solver.py
+++ b/test/test_modules/test_cg/test_cg_solver.py
@@ -45,9 +45,9 @@ def test_save_weights():
             dtype='float32'
         )
     )
-    weights1 = sol.octrees_output[0].outputs_centers[0].weights
-    weights2 = sol.octrees_output[0].outputs_centers[1].weights
-    weights3 = sol.octrees_output[0].outputs_centers[2].weights
+    weights1 = sol.octrees_output[0].outputs[0].weights
+    weights2 = sol.octrees_output[0].outputs[1].weights
+    weights3 = sol.octrees_output[0].outputs[2].weights
 
     WeightCache.clear_cache()
     BackendTensor.PYKEOPS = False

--- a/test/test_modules/test_faults/test_finite_faults.test_finite_fault_scalar_field_on_fault.verify/fault.approved.txt
+++ b/test/test_modules/test_faults/test_finite_faults.test_finite_fault_scalar_field_on_fault.verify/fault.approved.txt
@@ -220,7 +220,7 @@
             "compute_scalar_gradient": false,
             "verbose": false
         },
-        "debug": true,
+        "debug": false,
         "cache_mode": 3,
         "cache_model_name": "fault",
         "block_solutions_type": 1,

--- a/test/test_modules/test_geophysics/test_gravity.test_gravity.verify/2-layers.approved.txt
+++ b/test/test_modules/test_geophysics/test_gravity.test_gravity.verify/2-layers.approved.txt
@@ -174,7 +174,7 @@
             "compute_scalar_gradient": false,
             "verbose": false
         },
-        "debug": true,
+        "debug": false,
         "cache_mode": 3,
         "cache_model_name": "2-layers",
         "block_solutions_type": 2,

--- a/test/test_modules/test_grids/test_custom_grid.test_custom_grid.verify/fold.approved.txt
+++ b/test/test_modules/test_grids/test_custom_grid.test_custom_grid.verify/fold.approved.txt
@@ -152,7 +152,7 @@
             "compute_scalar_gradient": false,
             "verbose": false
         },
-        "debug": true,
+        "debug": false,
         "cache_mode": 3,
         "cache_model_name": "fold",
         "block_solutions_type": 1,

--- a/test/test_modules/test_grids/test_grids_sections.test_section_grids.verify/fold.approved.txt
+++ b/test/test_modules/test_grids/test_grids_sections.test_section_grids.verify/fold.approved.txt
@@ -219,7 +219,7 @@
             "compute_scalar_gradient": false,
             "verbose": false
         },
-        "debug": true,
+        "debug": false,
         "cache_mode": 3,
         "cache_model_name": "fold",
         "block_solutions_type": 1,

--- a/test/test_modules/test_grids/test_grids_sections.test_topography_II.verify/Model1.approved.txt
+++ b/test/test_modules/test_grids/test_grids_sections.test_topography_II.verify/Model1.approved.txt
@@ -219,7 +219,7 @@
             "compute_scalar_gradient": false,
             "verbose": false
         },
-        "debug": true,
+        "debug": false,
         "cache_mode": 3,
         "cache_model_name": "Model1",
         "block_solutions_type": 2,

--- a/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
+++ b/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
@@ -152,7 +152,7 @@
             "compute_scalar_gradient": false,
             "verbose": false
         },
-        "debug": true,
+        "debug": false,
         "cache_mode": 3,
         "cache_model_name": "horizontal",
         "block_solutions_type": 2,

--- a/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
+++ b/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
@@ -2,8 +2,11 @@ import os
 
 import dotenv
 import numpy as np
-import torch
 import time
+import pytest
+
+torch = pytest.importorskip("torch")
+
 import gempy as gp
 
 from ._aux_func import process_file, initialize_geo_model
@@ -23,7 +26,8 @@ start_time = time.time()
 # Load necessary configuration and paths from environment variables
 path = os.getenv("PATH_TO_NUGGET_TEST_MODEL")
 
-
+# Skip if not torch
+@pytest.mark.skipif(gp.data.AvailableBackends.PYTORCH not in gp.data.available_backends(), reason="Torch not available")
 def test_optimize_nugget_effect():
     # Initialize lists to store structural elements for the geological model
     structural_elements = []

--- a/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
+++ b/test/test_private/test_terranigma/test_nuggets/test_nugget_effect_optimization.py
@@ -26,8 +26,8 @@ start_time = time.time()
 # Load necessary configuration and paths from environment variables
 path = os.getenv("PATH_TO_NUGGET_TEST_MODEL")
 
+
 # Skip if not torch
-@pytest.mark.skipif(gp.data.AvailableBackends.PYTORCH not in gp.data.available_backends(), reason="Torch not available")
 def test_optimize_nugget_effect():
     # Initialize lists to store structural elements for the geological model
     structural_elements = []
@@ -68,7 +68,7 @@ def test_optimize_nugget_effect():
         ),
         validate_serialization=True
     )
-    
+
     print(f"Final cond number: {geo_model.interpolation_options.kernel_options.condition_number}")
     nugget_effect = geo_model.taped_interpolation_input.surface_points.nugget_effect_scalar.detach().numpy()
 
@@ -112,7 +112,7 @@ def test_optimize_nugget_effect():
             if False:
                 ori_cloud = pv.PolyData(geo_model.orientations_copy.df[['X', 'Y', 'Z']].to_numpy())
                 ori_cloud['values2'] = geo_model.taped_interpolation_input.orientations.nugget_effect_grad.detach().numpy()
-                
+
                 gempy_vista.p.add_mesh(
                     ori_cloud,
                     scalars='values2',


### PR DESCRIPTION
# Description

This change refactors the octree output data structure by renaming the `outputs_centers` attribute to `outputs` throughout the codebase. The change affects multiple modules including compatibility layers, engine factory, mesh extraction, and test files. Additionally, the debug flag is set to `false` in several test verification files, and a torch availability check is added to the nugget effect optimization test