### PR TITLE
[ENH] Add elements_enumerator, custom octree base resolution, and minor cleanups

### DIFF
--- a/gempy/core/data/grid.py
+++ b/gempy/core/data/grid.py
@@ -125,12 +125,12 @@ class Grid:
         self._update_values()
 
     @classmethod
-    def init_octree_grid(cls, extent, octree_levels, legacy: bool = False):
+    def init_octree_grid(cls, extent, octree_levels, base_resolution: Optional[np.ndarray] = None, legacy: bool = False):
         grid = cls()
 
         if legacy:
             base_resolution = (np.array([2, 2, 2]))
-        else:
+        elif base_resolution is None:
             lengths = np.array([
                     extent[1] - extent[0],  # x
                     extent[3] - extent[2],  # y

--- a/gempy/core/data/grid_modules/regular_grid.py
+++ b/gempy/core/data/grid_modules/regular_grid.py
@@ -108,7 +108,7 @@ class RegularGrid:
         def _calculate_rotated_box_val(v1, v2):
             # Check if the points are collinear
             # noinspection PyUnreachableCode
-            cross = np.cross(v1[:2], v2[:2])
+            cross = np.cross(v1, v2)[2]
             if np.isclose(cross, 0):
                 raise ValueError("The points are collinear")
             # Check if v1 and v2 are perpendicular

--- a/gempy/core/data/structural_frame.py
+++ b/gempy/core/data/structural_frame.py
@@ -32,7 +32,7 @@ class StructuralFrame:
     """
 
     structural_groups: list[StructuralGroup]
-    color_generator: ColorsGenerator =  Field(default_factory=ColorsGenerator)
+    color_generator: ColorsGenerator = Field(default_factory=ColorsGenerator)
     basement_color: str = None
     # ? Should I create some sort of structural options class? For example, the masking descriptor and faults relations pointer
     is_dirty: bool = True
@@ -42,7 +42,7 @@ class StructuralFrame:
     def __init__(self, structural_groups: list[StructuralGroup], color_gen: ColorsGenerator):
         self.structural_groups = structural_groups  # ? This maybe could be optional
         self.color_generator = color_gen
-        
+
     def __post_init__(self):
         pass
 
@@ -207,7 +207,6 @@ class StructuralFrame:
         """Returns the total number of elements in the structural frame."""
         return len(self.structural_elements)
 
-
     @property
     def _basement_element(self) -> StructuralElement:
         """Returns the basement structural element with a unique color."""
@@ -226,7 +225,7 @@ class StructuralFrame:
 
         if self.basement_color is None or self.basement_color in used_colors:
             self.basement_color = _get_unique_basement_color(
-                color_generator=self.color_generator, 
+                color_generator=self.color_generator,
                 used_colors=used_colors
             )
 
@@ -365,9 +364,14 @@ class StructuralFrame:
         return [element.name for element in self.structural_elements]
 
     @property
+    def elements_enumerator(self) -> np.ndarray:
+        """Returns an array of enumeration for all structural elements."""
+        return np.arange(len(self.structural_elements)) + 1
+
+    @property
     def elements_ids(self) -> np.ndarray:
         """Returns an array of IDs for all structural elements."""
-        return np.arange(len(self.structural_elements)) + 1
+        return [element.id for element in self.structural_elements]
 
     @property
     def surface_points_copy(self) -> SurfacePointsTable:
@@ -402,7 +406,7 @@ class StructuralFrame:
         """Distributes the modified orientations back to the structural elements."""
         for element in self.structural_elements:
             element.orientations.data = modified_orientations.get_orientations_by_id(element.id).data
-            
+
     @property
     def input_tables_binary(self):
         return self.surface_points_copy.data.tobytes() + self.orientations_copy.data.tobytes()
@@ -507,8 +511,8 @@ class StructuralFrame:
     @computed_field
     def binary_meta_data(self) -> dict:
         return {
-                'sp_binary_length': len(self.surface_points_copy.data.tobytes()),
-                'ori_binary_length': len(self.orientations_copy.data.tobytes()) ,
+                'sp_binary_length' : len(self.surface_points_copy.data.tobytes()),
+                'ori_binary_length': len(self.orientations_copy.data.tobytes()),
         }
 
     # endregion

--- a/gempy/core/data/structural_frame.py
+++ b/gempy/core/data/structural_frame.py
@@ -371,7 +371,7 @@ class StructuralFrame:
     @property
     def elements_ids(self) -> np.ndarray:
         """Returns an array of IDs for all structural elements."""
-        return [element.id for element in self.structural_elements]
+        return np.array([element.id for element in self.structural_elements])
 
     @property
     def surface_points_copy(self) -> SurfacePointsTable:

--- a/gempy/modules/data_manipulation/_engine_factory.py
+++ b/gempy/modules/data_manipulation/_engine_factory.py
@@ -51,7 +51,7 @@ def interpolation_input_from_structural_frame(geo_model: "gempy.data.GeoModel") 
         surface_points=surface_points,
         orientations=orientations,
         grid=grid,
-        unit_values=structural_frame.elements_ids,  # TODO: Here we will need to pass densities etc.
+        unit_values=structural_frame.elements_enumerator,  # TODO: Here we will need to pass densities etc.
         weights=weights
     )
 


### PR DESCRIPTION
# Description

Adds an optional `base_resolution` parameter to `init_octree_grid`, allowing callers to provide a custom base resolution instead of relying solely on the auto-computed or legacy defaults.

Separates the concept of element enumeration from element IDs in `StructuralFrame`. A new `elements_enumerator` property returns a sequential array (`1, 2, 3, ...`) for use in interpolation, while `elements_ids` now correctly returns the actual unique IDs assigned to each structural element. The interpolation input factory is updated to use `elements_enumerator` instead of `elements_ids` to preserve correct unit value ordering during interpolation.

Relates to <issue>

# Checklist
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] I have created tests which cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New tests pass locally with my changes.