### PR TITLE
[ENH] Add `CustomInterpolationFunctions`, filtered structural elements, and NULL_SPACE group support

### DIFF
--- a/gempy/core/data/__init__.py
+++ b/gempy/core/data/__init__.py
@@ -16,6 +16,7 @@ from gempy_engine.core.data.stack_relation_type import StackRelationType
 from gempy_engine.core.data.options import InterpolationOptions
 from gempy_engine.core.data.solutions import Solutions
 from gempy_engine.core.data.raw_arrays_solution import RawArraysSolution
+from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
 from gempy_engine.core.data.transforms import GlobalAnisotropy, Transform
 from gempy_engine.core.data.kernel_classes.faults import FaultsData, FiniteFaultData
 from gempy_engine.config import AvailableBackends
@@ -29,5 +30,5 @@ __all__ = [
     'ImporterHelper', 'GemPyEngineConfig', 'FaultsRelationSpecialCase', 'ColorsGenerator', 'ModelValidationError',
     # From gempy engine
     'InterpolationInput','StackRelationType', 'InterpolationOptions', 'Solutions', 'RawArraysSolution', 'GlobalAnisotropy', 'Transform',
-    'FaultsData', 'FiniteFaultData', 'AvailableBackends', 'GeophysicsInput'
+    'FaultsData', 'FiniteFaultData', 'AvailableBackends', 'GeophysicsInput', 'CustomInterpolationFunctions'
 ]

--- a/gempy/core/data/geo_model.py
+++ b/gempy/core/data/geo_model.py
@@ -104,7 +104,7 @@ class GeoModel(BaseModel):
         self._solutions = value
 
         # * Set solutions per element
-        for e, element in enumerate(self.structural_frame.structural_elements[:-1]):  # * Ignore basement
+        for e, element in enumerate(self.structural_frame.structural_elements_filtered[:-1]):  # * Ignore basement
             element.scalar_field_at_interface = value.scalar_field_at_surface_points[e]
 
             if self._solutions.dc_meshes is None:

--- a/gempy/core/data/grid.py
+++ b/gempy/core/data/grid.py
@@ -266,8 +266,9 @@ class Grid:
     @topography.setter
     def topography(self, value):
         self._topography = value
-        self.active_grids |= self.GridTypes.TOPOGRAPHY
-        self._update_values()
+        if value is not None:
+            self.active_grids |= self.GridTypes.TOPOGRAPHY
+            self._update_values()
 
     @property
     def sections(self):

--- a/gempy/core/data/structural_frame.py
+++ b/gempy/core/data/structural_frame.py
@@ -203,6 +203,18 @@ class StructuralFrame:
         elements.append(self._basement_element)
         return elements
 
+
+    @property
+    def structural_elements_filtered(self) -> list[StructuralElement]:
+        """Returns a list of all structural elements across the structural groups."""
+        elements = []
+        for group in self.structural_groups:
+            if group.structural_relation == StackRelationType.NULL_SPACE:
+                continue
+            elements.extend(group.elements)
+        elements.append(self._basement_element)
+        return elements
+
     @property
     def n_elements(self) -> int:
         """Returns the total number of elements in the structural frame."""

--- a/gempy/core/data/structural_group.py
+++ b/gempy/core/data/structural_group.py
@@ -2,7 +2,9 @@
 from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Optional, Union, Generator
+from typing import Annotated, Optional, Union, Generator
+
+from pydantic import Field
 
 from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
 from gempy_engine.core.data.kernel_classes.faults import FaultsData
@@ -31,8 +33,8 @@ class StructuralGroup(ABC):
     #: Relations with other groups in terms of faults.
     fault_relations: Optional[Union[list["StructuralGroup"], FaultsRelationSpecialCase]] = field(default=None, repr=False)
     faults_input_data: Optional[FaultsData] = field(default=None, repr=False)
-    custom_interpolation: Optional[CustomInterpolationFunctions] = field(default=None, repr=False)
-    ignored_grid_types: tuple[str, ...] = field(default=(), repr=False)
+    custom_interpolation: Annotated[Optional[CustomInterpolationFunctions], Field(exclude=True)] = field(default=None, repr=False)
+    ignored_grid_types: Annotated[tuple[str, ...], Field(exclude=True)] = field(default_factory=tuple, repr=False)
 
     solution: Optional[RawArraysSolution] = field(init=False, default=None, repr=False)  #: Solution related to this group from geological computations.
     

--- a/gempy/core/data/structural_group.py
+++ b/gempy/core/data/structural_group.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Optional, Union, Generator
 
+from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
 from gempy_engine.core.data.kernel_classes.faults import FaultsData
 from gempy_engine.core.data.raw_arrays_solution import RawArraysSolution
 from gempy_engine.core.data.stack_relation_type import StackRelationType
@@ -30,7 +31,8 @@ class StructuralGroup(ABC):
     #: Relations with other groups in terms of faults.
     fault_relations: Optional[Union[list["StructuralGroup"], FaultsRelationSpecialCase]] = field(default=None, repr=False)
     faults_input_data: Optional[FaultsData] = field(default=None, repr=False)
-    
+    custom_interpolation: Optional[CustomInterpolationFunctions] = field(default=None, repr=False)
+
     solution: Optional[RawArraysSolution] = field(init=False, default=None, repr=False)  #: Solution related to this group from geological computations.
     
     

--- a/gempy/core/data/structural_group.py
+++ b/gempy/core/data/structural_group.py
@@ -32,6 +32,7 @@ class StructuralGroup(ABC):
     fault_relations: Optional[Union[list["StructuralGroup"], FaultsRelationSpecialCase]] = field(default=None, repr=False)
     faults_input_data: Optional[FaultsData] = field(default=None, repr=False)
     custom_interpolation: Optional[CustomInterpolationFunctions] = field(default=None, repr=False)
+    ignored_grid_types: tuple[str, ...] = field(default=(), repr=False)
 
     solution: Optional[RawArraysSolution] = field(init=False, default=None, repr=False)  #: Solution related to this group from geological computations.
     

--- a/gempy/modules/data_manipulation/manipulate_structural_frame.py
+++ b/gempy/modules/data_manipulation/manipulate_structural_frame.py
@@ -1,20 +1,24 @@
-﻿from gempy_engine.core.data.stack_relation_type import StackRelationType
+﻿from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
+from gempy_engine.core.data.stack_relation_type import StackRelationType
 from gempy.core.data import StructuralGroup, GeoModel, FaultsRelationSpecialCase, StructuralElement, StructuralFrame
 
 
 def add_structural_group(
         model: GeoModel, group_index: int, structural_group_name: str, elements: list[StructuralElement],
-        structural_relation: StackRelationType, fault_relations: FaultsRelationSpecialCase = FaultsRelationSpecialCase.OFFSET_ALL) -> StructuralFrame:
-    
+        structural_relation: StackRelationType,
+        fault_relations: FaultsRelationSpecialCase = FaultsRelationSpecialCase.OFFSET_ALL,
+        custom_interpolation: CustomInterpolationFunctions = None) -> StructuralFrame:
+
     # Check elements are a Sequence
     if not isinstance(elements, list):
         raise TypeError("elements must be a list of StructuralElement objects.")
-    
+
     new_group = StructuralGroup(
         name=structural_group_name,
         elements=elements,
         structural_relation=structural_relation,
-        fault_relations=fault_relations
+        fault_relations=fault_relations,
+        custom_interpolation=custom_interpolation
     )
 
     # Insert the fault group into the structural frame:

--- a/gempy/modules/serialization/save_load.py
+++ b/gempy/modules/serialization/save_load.py
@@ -65,7 +65,6 @@ def save_model(model: GeoModel, path: str | None = None, validate_serialization:
 
 
 def model_to_binary(model: GeoModel) -> bytes:
-
     # Compress the binary data
     zlib = require_zlib()
     compressed_binary_input = zlib.compress(model.structural_frame.input_tables_binary)
@@ -75,7 +74,7 @@ def model_to_binary(model: GeoModel) -> bytes:
 
     import hashlib
     print("len raw bytes:", len(model.grid.grid_binary))
-    
+
     print("raw bytes hash:", hashlib.sha256(model.grid.grid_binary).hexdigest())
     print("compressed length:", len(compressed_binary_grid))
     print("zlib version:", zlib.ZLIB_VERSION)
@@ -83,7 +82,7 @@ def model_to_binary(model: GeoModel) -> bytes:
     # * Add here the serialization meta parameters like: len_bytes
     model.structural_frame._input_binary_size = len(compressed_binary_input)
     model.grid._grid_binary_size = len(compressed_binary_grid)
-    
+
     model_json = model.model_dump_json(by_alias=True, indent=4)
     binary_file = _to_binary(
         header_json=model_json,
@@ -143,10 +142,10 @@ def model_to_bytes(model: GeoModel) -> bytes:
 
     # 2) Raw binary chunks (no additional zlib.compress here)
     input_raw = model.structural_frame.input_tables_binary
-    grid_raw  = model.grid.grid_binary
+    grid_raw = model.grid.grid_binary
 
     # 3) Pack into a ZIP archive in a fixed order:
-    
+
     buf = io.BytesIO()
     with zipfile.ZipFile(
             buf, mode="w",
@@ -155,15 +154,16 @@ def model_to_bytes(model: GeoModel) -> bytes:
     ) as zf:
         # Force a fixed timestamp (1980-01-01) so the file headers don't vary
         def make_info(name):
-            zi = zipfile.ZipInfo(name, date_time=(1980,1,1,0,0,0))
+            zi = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
             zi.external_attr = 0  # clear OS-specific file permissions
             return zi
 
         zf.writestr(make_info("header.json"), header_json)
-        zf.writestr(make_info("input.bin"),   input_raw)
-        zf.writestr(make_info("grid.bin"),    grid_raw)
+        zf.writestr(make_info("input.bin"), input_raw)
+        zf.writestr(make_info("grid.bin"), grid_raw)
 
     return buf.getvalue()
+
 
 def _load_model_from_bytes(data: bytes) -> GeoModel:
     from ...core.data.encoders.converters import loading_model_from_binary
@@ -171,57 +171,55 @@ def _load_model_from_bytes(data: bytes) -> GeoModel:
     buf = io.BytesIO(data)
     with zipfile.ZipFile(buf, "r") as zf:
         header_json = zf.read("header.json").decode("utf-8")
-        input_raw   = zf.read("input.bin")
-        grid_raw    = zf.read("grid.bin")
-        meshes_json = zf.read("static_meshes.json").decode("utf-8")
+        input_raw = zf.read("input.bin")
+        grid_raw = zf.read("grid.bin")
 
     header_dict = json.loads(header_json)
     pending = StructuralFrame._extract_and_clear_fault_relation_names(
         header_dict.get('structural_frame', {}).get('structural_groups', [])
     )
-    
-    meshes_dict = json.loads(meshes_json)
-    
+
     with loading_model_from_binary(
             input_binary=input_raw,
-            grid_binary= grid_raw
+            grid_binary=grid_raw
     ):
         model = GeoModel.model_validate(header_dict)
 
     model.structural_frame.restore_fault_relations_from_names(pending)
     return model
 
+
 def _deserialize_binary_file(binary_file):
     import json
     # Get header length from first 4 bytes
     header_length = int.from_bytes(binary_file[:4], byteorder='little')
     # Split header and body
-    header_json= binary_file[4:4 + header_length].decode('utf-8')
+    header_json = binary_file[4:4 + header_length].decode('utf-8')
     header = json.loads(header_json)
     input_metadata = header["structural_frame"]["binary_meta_data"]
     input_size = input_metadata["input_binary_size"]
-    
+
     grid_metadata = header["grid"]["binary_meta_data"]
     grid_size = grid_metadata["grid_binary_size"]
-    
+
     input_binary = binary_file[4 + header_length: 4 + header_length + input_size]
     all_sections_length = 4 + header_length + input_size + grid_size
     if all_sections_length != len(binary_file):
-        raise  ValueError("Binary file is corrupted")
-    
+        raise ValueError("Binary file is corrupted")
+
     grid_binary = binary_file[4 + header_length + input_size: all_sections_length]
     zlib = require_zlib()
-    
+
     pending = StructuralFrame._extract_and_clear_fault_relation_names(
         header.get('structural_frame', {}).get('structural_groups', [])
     )
-    
+
     with loading_model_from_binary(
             input_binary=(zlib.decompress(input_binary)),
             grid_binary=(zlib.decompress(grid_binary))
     ):
         model = GeoModel.model_validate(header)
-    
+
     model.structural_frame.restore_fault_relations_from_names(pending)
     return model
 
@@ -254,5 +252,3 @@ def _validate_serialization(original_model, model_deserialized):
         print(f"Deserialized: {deserialized___str__[i - i1:i + i1]}")
 
     assert deserialized___str__ == original_model___str__
-
-

--- a/gempy/modules/serialization/save_load.py
+++ b/gempy/modules/serialization/save_load.py
@@ -173,12 +173,15 @@ def _load_model_from_bytes(data: bytes) -> GeoModel:
         header_json = zf.read("header.json").decode("utf-8")
         input_raw   = zf.read("input.bin")
         grid_raw    = zf.read("grid.bin")
+        meshes_json = zf.read("static_meshes.json").decode("utf-8")
 
     header_dict = json.loads(header_json)
     pending = StructuralFrame._extract_and_clear_fault_relation_names(
         header_dict.get('structural_frame', {}).get('structural_groups', [])
     )
-
+    
+    meshes_dict = json.loads(meshes_json)
+    
     with loading_model_from_binary(
             input_binary=input_raw,
             grid_binary= grid_raw

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
 # This install also numpy
-gempy_engine>=2026.0.3
+gempy_engine>=2026.1.0a1


### PR DESCRIPTION
# Description

Adds support for `CustomInterpolationFunctions` and `ignored_grid_types` on `StructuralGroup`, allowing per-group customization of the interpolation pipeline. `CustomInterpolationFunctions` is now exported from `gempy.core.data` and can be passed through `add_structural_group`.

Introduces `structural_elements_filtered`, a new property on `StructuralFrame` that excludes elements belonging to `NULL_SPACE` groups. This filtered list is now used when assigning scalar field values to elements via the `solutions` setter, preventing index mismatches when null-space groups are present.

Fixes a bug in the `topography` setter where setting the value to `None` would incorrectly activate the topography grid type and trigger a grid update.

Bumps the `gempy_engine` requirement to `>=2026.1.0a1` to pull in the `CustomInterpolationFunctions` API.

Relates to #

# Checklist
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] I have created tests which cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New tests pass locally with my changes.