### PR TITLE
[ENH] Add `FiniteFault` user-facing API with coordinate transform, enable/disable support, and serialization

### DIFF
--- a/gempy/API/compute_API.py
+++ b/gempy/API/compute_API.py
@@ -11,7 +11,10 @@ from .grid_API import set_custom_grid
 from ..core.data import StructuralGroup
 from ..core.data.gempy_engine_config import GemPyEngineConfig
 from ..core.data.geo_model import GeoModel
-from ..modules.data_manipulation import interpolation_input_from_structural_frame
+from ..modules.data_manipulation import (
+    input_data_descriptor_from_geo_model,
+    interpolation_input_from_structural_frame,
+)
 from ..modules.optimize_nuggets import nugget_optimizer
 
 dotenv.load_dotenv()
@@ -63,12 +66,13 @@ def compute_model(gempy_model: GeoModel, engine_config: Optional[GemPyEngineConf
 
             # TODO: To decide what to do with this.
             interpolation_input = interpolation_input_from_structural_frame(gempy_model)
+            input_data_descriptor = input_data_descriptor_from_geo_model(gempy_model)
             gempy_model.taped_interpolation_input = interpolation_input  # * This is used for gradient tape
 
             gempy_model.solutions = gempy_engine.compute_model(
                 interpolation_input=interpolation_input,
                 options=gempy_model.interpolation_options,
-                data_descriptor=gempy_model.input_data_descriptor,
+                data_descriptor=input_data_descriptor,
                 geophysics_input=gempy_model.geophysics_input,
             )
         case _:
@@ -144,5 +148,3 @@ def optimize_and_compute(geo_model: GeoModel, engine_config: GemPyEngineConfig, 
         geophysics_input=geo_model.geophysics_input,
     )
     return geo_model.solutions
-
-

--- a/gempy/core/data/__init__.py
+++ b/gempy/core/data/__init__.py
@@ -1,6 +1,6 @@
 from .geo_model import GeoModel
 from .structural_frame import StructuralFrame
-from .structural_group import StructuralGroup
+from .structural_group import StructuralGroup, FaultType
 from .structural_element import StructuralElement
 from .orientations import OrientationsTable
 from .surface_points import SurfacePointsTable
@@ -18,7 +18,8 @@ from gempy_engine.core.data.solutions import Solutions
 from gempy_engine.core.data.raw_arrays_solution import RawArraysSolution
 from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
 from gempy_engine.core.data.transforms import GlobalAnisotropy, Transform
-from gempy_engine.core.data.kernel_classes.faults import FaultsData, FiniteFaultData
+from gempy_engine.core.data.finite_fault import FiniteFault, TaperType
+from gempy_engine.core.data.kernel_classes.faults import FaultsData
 from gempy_engine.config import AvailableBackends
 from gempy_engine.core.data.geophysics_input import GeophysicsInput
 
@@ -30,5 +31,5 @@ __all__ = [
     'ImporterHelper', 'GemPyEngineConfig', 'FaultsRelationSpecialCase', 'ColorsGenerator', 'ModelValidationError',
     # From gempy engine
     'InterpolationInput','StackRelationType', 'InterpolationOptions', 'Solutions', 'RawArraysSolution', 'GlobalAnisotropy', 'Transform',
-    'FaultsData', 'FiniteFaultData', 'AvailableBackends', 'GeophysicsInput', 'CustomInterpolationFunctions'
+    'FaultsData', 'FiniteFault', 'TaperType', 'FaultType', 'AvailableBackends', 'GeophysicsInput', 'CustomInterpolationFunctions'
 ]

--- a/gempy/core/data/structural_group.py
+++ b/gempy/core/data/structural_group.py
@@ -3,9 +3,11 @@ from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Annotated, Optional, Union, Generator
+from uuid import uuid4
 
 from pydantic import Field
 
+from gempy_engine.core.data.finite_fault import FiniteFault
 from gempy_engine.core.data.interpolation_functions import CustomInterpolationFunctions
 from gempy_engine.core.data.kernel_classes.faults import FaultsData
 from gempy_engine.core.data.raw_arrays_solution import RawArraysSolution
@@ -17,6 +19,12 @@ class FaultsRelationSpecialCase(Enum):
     OFFSET_FORMATIONS = auto()
     OFFSET_NONE = auto()
     OFFSET_ALL = auto()
+
+
+class FaultType(str, Enum):
+    INFINITE = "Infinite"
+    FINITE = "Finite"
+    DISABLED = "Disabled"
     
     
 @dataclass
@@ -29,10 +37,12 @@ class StructuralGroup(ABC):
     
     elements: list[StructuralElement] = field(repr=False)  #: A list of structural elements within the group.
     structural_relation: StackRelationType  #: The type of relation between the structural elements in the group.
+    id: Annotated[Optional[str], Field(exclude=True)] = field(default=None)
 
     #: Relations with other groups in terms of faults.
     fault_relations: Optional[Union[list["StructuralGroup"], FaultsRelationSpecialCase]] = field(default=None, repr=False)
     faults_input_data: Optional[FaultsData] = field(default=None, repr=False)
+    finite_fault_draft: Annotated[Optional[FiniteFault], Field(exclude=True)] = field(default=None, repr=False)
     custom_interpolation: Annotated[Optional[CustomInterpolationFunctions], Field(exclude=True)] = field(default=None, repr=False)
     ignored_grid_types: Annotated[tuple[str, ...], Field(exclude=True)] = field(default_factory=tuple, repr=False)
 
@@ -40,6 +50,8 @@ class StructuralGroup(ABC):
     
     
     def __post_init__(self):
+        if self.id is None:
+            self.id = str(uuid4())
         if not isinstance(self.elements, list):
             raise TypeError("elements must be a list of StructuralElement objects.")
         for e in self.elements:
@@ -72,12 +84,31 @@ class StructuralGroup(ABC):
         self.elements.remove(element)
 
     @property
-    def id(self):
-        raise NotImplementedError
-    
-    @property
     def is_fault(self)-> bool:
         return self.structural_relation == StackRelationType.FAULT
+
+    @property
+    def fault_type(self) -> FaultType:
+        finite_fault = self.faults_input_data.finite_fault if self.faults_input_data is not None else None
+        if finite_fault is not None:
+            return FaultType.FINITE
+        if self.finite_fault_draft is not None:
+            return FaultType.DISABLED
+        return FaultType.INFINITE
+
+    def set_finite_fault(self, finite_fault: FiniteFault) -> None:
+        self.faults_input_data = FaultsData.from_user_input(thickness=None, finite_fault=finite_fault)
+        self.finite_fault_draft = None
+
+    def disable_finite_fault(self) -> None:
+        if self.fault_type is not FaultType.FINITE:
+            return
+        self.finite_fault_draft = self.faults_input_data.finite_fault
+        self.faults_input_data.finite_fault = None
+
+    def enable_finite_fault(self) -> None:
+        if self.finite_fault_draft is not None:
+            self.set_finite_fault(self.finite_fault_draft)
     
     @property
     def is_lithology(self)-> bool:

--- a/gempy/modules/data_manipulation/__init__.py
+++ b/gempy/modules/data_manipulation/__init__.py
@@ -1,1 +1,1 @@
-from ._engine_factory import interpolation_input_from_structural_frame
+from ._engine_factory import input_data_descriptor_from_geo_model, interpolation_input_from_structural_frame

--- a/gempy/modules/data_manipulation/_engine_factory.py
+++ b/gempy/modules/data_manipulation/_engine_factory.py
@@ -5,9 +5,11 @@ import numpy as np
 from ...core.data.grid import Grid
 from ...core.data.structural_frame import StructuralFrame
 
-from gempy_engine.core.data import SurfacePoints, Orientations
+from gempy_engine.core.data import FiniteFault, Orientations, SurfacePoints
 from gempy_engine.core.data import engine_grid
+from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
 from gempy_engine.core.data.interpolation_input import InterpolationInput
+from gempy_engine.core.data.kernel_classes.faults import FaultsData
 from gempy_engine.core.data.transforms import Transform
 
 
@@ -56,6 +58,59 @@ def interpolation_input_from_structural_frame(geo_model: "gempy.data.GeoModel") 
     )
 
     return interpolation_input
+
+
+def input_data_descriptor_from_geo_model(geo_model: "gempy.data.GeoModel") -> InputDataDescriptor:
+    """Build an engine descriptor with finite-fault geometry in engine coordinates."""
+    descriptor = geo_model.input_data_descriptor
+    faults_input_data = descriptor.stack_structure.faults_input_data
+    if faults_input_data is None or not any(
+            fault_data is not None and fault_data.finite_fault_defined
+            for fault_data in faults_input_data
+    ):
+        return descriptor
+
+    total_scale = geo_model.input_transform.scale * geo_model.grid.transform.scale
+    if not np.allclose(total_scale, total_scale[0]):
+        raise ValueError("Finite faults require an isotropic model transform")
+    if not (
+            np.allclose(geo_model.input_transform.rotation[:2], 0.0)
+            and np.allclose(geo_model.grid.transform.rotation[:2], 0.0)
+    ):
+        raise ValueError("Finite faults do not support model transforms that tilt the vertical axis")
+
+    scale = float(total_scale[0])
+    transformed_faults_input_data = []
+    for fault_data in faults_input_data:
+        if fault_data is None or not fault_data.finite_fault_defined:
+            transformed_faults_input_data.append(fault_data)
+            continue
+
+        finite_fault = fault_data.finite_fault
+        center = np.atleast_2d(finite_fault.center)
+        center = geo_model.grid.transform.apply_with_cached_pivot(center)
+        center = geo_model.input_transform.apply(center)[0]
+        transformed_finite_fault = FiniteFault(
+            center=tuple(center),
+            strike_radius=_scale_radius(finite_fault.strike_radius, scale),
+            dip_radius=_scale_radius(finite_fault.dip_radius, scale),
+            taper=finite_fault.taper,
+            rotation_deg=finite_fault.rotation_deg,
+            spline_control_points=finite_fault.spline_control_points,
+        )
+        transformed_faults_input_data.append(FaultsData.from_user_input(
+            thickness=fault_data.thickness,
+            finite_fault=transformed_finite_fault,
+        ))
+
+    descriptor.stack_structure.faults_input_data = transformed_faults_input_data
+    return descriptor
+
+
+def _scale_radius(radius: float | tuple[float, float], scale: float) -> float | tuple[float, float]:
+    if isinstance(radius, tuple):
+        return tuple(value * scale for value in radius)
+    return radius * scale
 
 
 def _apply_input_transform_to_grids(grid: Grid, input_transform: Transform, extent_transformed: np.ndarray) -> engine_grid.EngineGrid:

--- a/gempy/modules/serialization/save_load.py
+++ b/gempy/modules/serialization/save_load.py
@@ -6,6 +6,8 @@ import warnings
 
 from ...core.data import GeoModel
 from ...core.data.structural_frame import StructuralFrame
+from gempy_engine.core.data import FiniteFault
+from pydantic import TypeAdapter
 from ...core.data.encoders.converters import loading_model_from_binary
 from ...optional_dependencies import require_zlib
 import pathlib
@@ -161,6 +163,7 @@ def model_to_bytes(model: GeoModel) -> bytes:
         zf.writestr(make_info("header.json"), header_json)
         zf.writestr(make_info("input.bin"), input_raw)
         zf.writestr(make_info("grid.bin"), grid_raw)
+        zf.writestr(make_info("liquid_earth_meta.json"), _liquid_earth_meta_json(model))
 
     return buf.getvalue()
 
@@ -173,6 +176,10 @@ def _load_model_from_bytes(data: bytes) -> GeoModel:
         header_json = zf.read("header.json").decode("utf-8")
         input_raw = zf.read("input.bin")
         grid_raw = zf.read("grid.bin")
+        try:
+            liquid_earth_meta = json.loads(zf.read("liquid_earth_meta.json").decode("utf-8"))
+        except KeyError:
+            liquid_earth_meta = None
 
     header_dict = json.loads(header_json)
     pending = StructuralFrame._extract_and_clear_fault_relation_names(
@@ -186,7 +193,33 @@ def _load_model_from_bytes(data: bytes) -> GeoModel:
         model = GeoModel.model_validate(header_dict)
 
     model.structural_frame.restore_fault_relations_from_names(pending)
+    _restore_liquid_earth_meta(model, liquid_earth_meta)
     return model
+
+
+def _liquid_earth_meta_json(model: GeoModel) -> str:
+    finite_fault_adapter = TypeAdapter(FiniteFault)
+    groups = []
+    for group in model.structural_frame.structural_groups:
+        draft = group.finite_fault_draft
+        groups.append({
+                "id": group.id,
+                "finite_fault_draft": finite_fault_adapter.dump_python(draft, mode="json") if draft is not None else None,
+        })
+    return json.dumps({"static_meshes": [], "structural_groups": groups}, indent=4)
+
+
+def _restore_liquid_earth_meta(model: GeoModel, metadata: dict | None) -> None:
+    if metadata is None:
+        return
+
+    finite_fault_adapter = TypeAdapter(FiniteFault)
+    group_metadata_items = metadata.get("structural_groups", [])
+    for group, group_metadata in zip(model.structural_frame.structural_groups, group_metadata_items):
+        group.id = group_metadata.get("id") or group.id
+        draft = group_metadata.get("finite_fault_draft")
+        if draft is not None:
+            group.finite_fault_draft = finite_fault_adapter.validate_python(draft)
 
 
 def _deserialize_binary_file(binary_file):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
 # This install also numpy
-gempy_engine>=2026.1.0a1
+gempy_engine>=2026.1.1a1

--- a/test/test_modules/test_faults/test_finite_faults.py
+++ b/test/test_modules/test_faults/test_finite_faults.py
@@ -24,33 +24,19 @@ def test_finite_fault_scalar_field_on_fault():
 
     regular_grid = geo_model.grid.regular_grid
 
-    # TODO: Extract grid from the model
-    scaled_center = geo_model.input_transform.apply(center.reshape(1, -1))[0]
-    scaled_radius = geo_model.input_transform.scale_points(radius.reshape(1, -1))[0]
-    scalar_funtion: callable = gp.implicit_functions.ellipsoid_3d_factory(  # * This paints the 3d regular grid
-        center=scaled_center,
-        radius=scaled_radius,
-        max_slope=k  # * This controls the speed of the transition
-    )
     transform = gp.data.Transform(
         position=np.array([0, 0, 0]),
         rotation=np.array([0, 60, 0]),
         scale=np.ones(3)
     )
-    faults_data = gp.data.FaultsData(
-        fault_values_everywhere=np.zeros(0),
-        fault_values_on_sp=np.zeros(0),
-        thickness=None,
-        fault_values_ref=np.zeros(0),
-        fault_values_rest=np.zeros(0),
-        finite_fault_data=gp.data.FiniteFaultData(
-            implicit_function=scalar_funtion,
-            implicit_function_transform=transform,
-            pivot=scaled_center,
-        )
+    finite_fault = gp.data.FiniteFault(
+        center=tuple(center),
+        strike_radius=float(radius[0]),
+        dip_radius=float(radius[2]),
+        rotation_deg=60.0,
     )
 
-    geo_model.structural_frame.structural_groups[0].faults_input_data = faults_data
+    geo_model.structural_frame.structural_groups[0].set_finite_fault(finite_fault)
 
     verify_model_serialization(
         model=geo_model,
@@ -62,7 +48,7 @@ def test_finite_fault_scalar_field_on_fault():
 
     # TODO: Try to do this afterwards
 
-    if plot_pyvista := True:
+    if PLOT:
         plot3d = gpv.plot_3d(
             geo_model,
             show_lith=False,

--- a/test/test_modules/test_faults/test_finite_faults.test_finite_fault_scalar_field_on_fault.verify/fault.approved.txt
+++ b/test/test_modules/test_faults/test_finite_faults.test_finite_fault_scalar_field_on_fault.verify/fault.approved.txt
@@ -42,31 +42,17 @@
                     "fault_values_ref": [],
                     "fault_values_rest": [],
                     "thickness": null,
-                    "finite_fault_data": {
-                        "implicit_function_transform": {
-                            "position": [
-                                0,
-                                0,
-                                0
-                            ],
-                            "rotation": [
-                                0,
-                                60,
-                                0
-                            ],
-                            "scale": [
-                                1.0,
-                                1.0,
-                                1.0
-                            ],
-                            "_is_default_transform": false,
-                            "_cached_pivot": null
-                        },
-                        "pivot": [
-                            0.0,
-                            0.0,
-                            0.0
-                        ]
+                    "finite_fault": {
+                        "center": [
+                            500.0,
+                            500.0,
+                            500.0
+                        ],
+                        "strike_radius": 250.0,
+                        "dip_radius": 100.0,
+                        "taper": "cubic",
+                        "rotation_deg": 60.0,
+                        "spline_control_points": null
                     }
                 },
                 "solution": null
@@ -204,7 +190,19 @@
             "kernel_solver": 1,
             "compute_condition_number": false,
             "optimizing_condition_number": false,
-            "condition_number": null
+            "condition_number": null,
+            "condition_number_before": null,
+            "condition_number_after": null,
+            "fault_drift_equilibration": true,
+            "fault_drift_regularization": 0.001,
+            "symmetric_equilibration_method": "none",
+            "symmetric_equilibration_max_iterations": 10,
+            "symmetric_equilibration_tolerance": 0.01,
+            "nugget_implementation": "legacy",
+            "drift_diagnostics": false,
+            "drift_rank_policy": "warn",
+            "drift_rank_rcond": null,
+            "drift_warning_rcond": null
         },
         "evaluation_options": {
             "_number_octree_levels": 6,
@@ -216,6 +214,18 @@
             "mesh_extraction_masking_options": 3,
             "mesh_extraction_fancy": true,
             "evaluation_chunk_size": 500000,
+            "micro_anisotropic": {
+                "enabled": false,
+                "points": null,
+                "residuals": null,
+                "anisotropy_matrices": null,
+                "weights": null,
+                "kernel_range": 1.0,
+                "kernel_type": "matern_5_2",
+                "nugget": 0.0,
+                "preserve_macro_points": true,
+                "strength": 1.0
+            },
             "compute_scalar": true,
             "compute_scalar_gradient": false,
             "verbose": false

--- a/test/test_modules/test_finite_fault_transform.py
+++ b/test/test_modules/test_finite_fault_transform.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+import gempy as gp
+from gempy.core.data.enumerators import ExampleModel
+from gempy.modules.data_manipulation import input_data_descriptor_from_geo_model
+
+
+def test_finite_fault_is_transformed_for_engine_without_mutating_model():
+    model = gp.generate_example_model(ExampleModel.ONE_FAULT, compute_model=False)
+    fault_group = model.structural_frame.structural_groups[0]
+    finite_fault = gp.data.FiniteFault(
+        center=(500.0, 400.0, 300.0),
+        strike_radius=(200.0, 100.0),
+        dip_radius=150.0,
+        taper=gp.data.TaperType.QUADRATIC,
+    )
+    fault_group.set_finite_fault(finite_fault)
+
+    descriptor = input_data_descriptor_from_geo_model(model)
+    transformed = descriptor.stack_structure.faults_input_data[0].finite_fault
+
+    expected_center = model.grid.transform.apply_with_cached_pivot(np.atleast_2d(finite_fault.center))
+    expected_center = model.input_transform.apply(expected_center)[0]
+    scale = float((model.input_transform.scale * model.grid.transform.scale)[0])
+    assert transformed.center == pytest.approx(expected_center)
+    assert transformed.strike_radius == pytest.approx((200.0 * scale, 100.0 * scale))
+    assert transformed.dip_radius == pytest.approx(150.0 * scale)
+    assert transformed.taper is finite_fault.taper
+    assert fault_group.faults_input_data.finite_fault is finite_fault
+
+
+def test_finite_fault_rejects_anisotropic_engine_transform():
+    model = gp.generate_example_model(ExampleModel.ONE_FAULT, compute_model=False)
+    model.structural_frame.structural_groups[0].set_finite_fault(
+        gp.data.FiniteFault(center=(500.0, 400.0, 300.0))
+    )
+    model.input_transform.scale = np.array([1.0, 2.0, 1.0])
+
+    with pytest.raises(ValueError, match="isotropic model transform"):
+        input_data_descriptor_from_geo_model(model)

--- a/test/test_modules/test_geophysics/test_gravity.test_gravity.verify/2-layers.approved.txt
+++ b/test/test_modules/test_geophysics/test_gravity.test_gravity.verify/2-layers.approved.txt
@@ -158,7 +158,19 @@
             "kernel_solver": 1,
             "compute_condition_number": false,
             "optimizing_condition_number": false,
-            "condition_number": null
+            "condition_number": null,
+            "condition_number_before": null,
+            "condition_number_after": null,
+            "fault_drift_equilibration": true,
+            "fault_drift_regularization": 0.001,
+            "symmetric_equilibration_method": "none",
+            "symmetric_equilibration_max_iterations": 10,
+            "symmetric_equilibration_tolerance": 0.01,
+            "nugget_implementation": "legacy",
+            "drift_diagnostics": false,
+            "drift_rank_policy": "warn",
+            "drift_rank_rcond": null,
+            "drift_warning_rcond": null
         },
         "evaluation_options": {
             "_number_octree_levels": 1,
@@ -170,6 +182,18 @@
             "mesh_extraction_masking_options": 3,
             "mesh_extraction_fancy": true,
             "evaluation_chunk_size": 500000,
+            "micro_anisotropic": {
+                "enabled": false,
+                "points": null,
+                "residuals": null,
+                "anisotropy_matrices": null,
+                "weights": null,
+                "kernel_range": 1.0,
+                "kernel_type": "matern_5_2",
+                "nugget": 0.0,
+                "preserve_macro_points": true,
+                "strength": 1.0
+            },
             "compute_scalar": true,
             "compute_scalar_gradient": false,
             "verbose": false

--- a/test/test_modules/test_grids/test_custom_grid.test_custom_grid.verify/fold.approved.txt
+++ b/test/test_modules/test_grids/test_custom_grid.test_custom_grid.verify/fold.approved.txt
@@ -136,7 +136,19 @@
             "kernel_solver": 1,
             "compute_condition_number": false,
             "optimizing_condition_number": false,
-            "condition_number": null
+            "condition_number": null,
+            "condition_number_before": null,
+            "condition_number_after": null,
+            "fault_drift_equilibration": true,
+            "fault_drift_regularization": 0.001,
+            "symmetric_equilibration_method": "none",
+            "symmetric_equilibration_max_iterations": 10,
+            "symmetric_equilibration_tolerance": 0.01,
+            "nugget_implementation": "legacy",
+            "drift_diagnostics": false,
+            "drift_rank_policy": "warn",
+            "drift_rank_rcond": null,
+            "drift_warning_rcond": null
         },
         "evaluation_options": {
             "_number_octree_levels": 2,
@@ -148,6 +160,18 @@
             "mesh_extraction_masking_options": 3,
             "mesh_extraction_fancy": true,
             "evaluation_chunk_size": 500000,
+            "micro_anisotropic": {
+                "enabled": false,
+                "points": null,
+                "residuals": null,
+                "anisotropy_matrices": null,
+                "weights": null,
+                "kernel_range": 1.0,
+                "kernel_type": "matern_5_2",
+                "nugget": 0.0,
+                "preserve_macro_points": true,
+                "strength": 1.0
+            },
             "compute_scalar": true,
             "compute_scalar_gradient": false,
             "verbose": false

--- a/test/test_modules/test_grids/test_grids_sections.test_section_grids.verify/fold.approved.txt
+++ b/test/test_modules/test_grids/test_grids_sections.test_section_grids.verify/fold.approved.txt
@@ -203,7 +203,19 @@
             "kernel_solver": 1,
             "compute_condition_number": false,
             "optimizing_condition_number": false,
-            "condition_number": null
+            "condition_number": null,
+            "condition_number_before": null,
+            "condition_number_after": null,
+            "fault_drift_equilibration": true,
+            "fault_drift_regularization": 0.001,
+            "symmetric_equilibration_method": "none",
+            "symmetric_equilibration_max_iterations": 10,
+            "symmetric_equilibration_tolerance": 0.01,
+            "nugget_implementation": "legacy",
+            "drift_diagnostics": false,
+            "drift_rank_policy": "warn",
+            "drift_rank_rcond": null,
+            "drift_warning_rcond": null
         },
         "evaluation_options": {
             "_number_octree_levels": 2,
@@ -215,6 +227,18 @@
             "mesh_extraction_masking_options": 3,
             "mesh_extraction_fancy": true,
             "evaluation_chunk_size": 500000,
+            "micro_anisotropic": {
+                "enabled": false,
+                "points": null,
+                "residuals": null,
+                "anisotropy_matrices": null,
+                "weights": null,
+                "kernel_range": 1.0,
+                "kernel_type": "matern_5_2",
+                "nugget": 0.0,
+                "preserve_macro_points": true,
+                "strength": 1.0
+            },
             "compute_scalar": true,
             "compute_scalar_gradient": false,
             "verbose": false

--- a/test/test_modules/test_grids/test_grids_sections.test_topography_II.verify/Model1.approved.txt
+++ b/test/test_modules/test_grids/test_grids_sections.test_topography_II.verify/Model1.approved.txt
@@ -203,7 +203,19 @@
             "kernel_solver": 1,
             "compute_condition_number": false,
             "optimizing_condition_number": false,
-            "condition_number": null
+            "condition_number": null,
+            "condition_number_before": null,
+            "condition_number_after": null,
+            "fault_drift_equilibration": true,
+            "fault_drift_regularization": 0.001,
+            "symmetric_equilibration_method": "none",
+            "symmetric_equilibration_max_iterations": 10,
+            "symmetric_equilibration_tolerance": 0.01,
+            "nugget_implementation": "legacy",
+            "drift_diagnostics": false,
+            "drift_rank_policy": "warn",
+            "drift_rank_rcond": null,
+            "drift_warning_rcond": null
         },
         "evaluation_options": {
             "_number_octree_levels": 1,
@@ -215,6 +227,18 @@
             "mesh_extraction_masking_options": 3,
             "mesh_extraction_fancy": true,
             "evaluation_chunk_size": 500000,
+            "micro_anisotropic": {
+                "enabled": false,
+                "points": null,
+                "residuals": null,
+                "anisotropy_matrices": null,
+                "weights": null,
+                "kernel_range": 1.0,
+                "kernel_type": "matern_5_2",
+                "nugget": 0.0,
+                "preserve_macro_points": true,
+                "strength": 1.0
+            },
             "compute_scalar": true,
             "compute_scalar_gradient": false,
             "verbose": false

--- a/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
+++ b/test/test_modules/test_serialize_model.test_generate_horizontal_stratigraphic_model.verify/Horizontal Stratigraphic Model serialization.approved.txt
@@ -136,7 +136,19 @@
             "kernel_solver": 1,
             "compute_condition_number": false,
             "optimizing_condition_number": false,
-            "condition_number": null
+            "condition_number": null,
+            "condition_number_before": null,
+            "condition_number_after": null,
+            "fault_drift_equilibration": true,
+            "fault_drift_regularization": 0.001,
+            "symmetric_equilibration_method": "none",
+            "symmetric_equilibration_max_iterations": 10,
+            "symmetric_equilibration_tolerance": 0.01,
+            "nugget_implementation": "legacy",
+            "drift_diagnostics": false,
+            "drift_rank_policy": "warn",
+            "drift_rank_rcond": null,
+            "drift_warning_rcond": null
         },
         "evaluation_options": {
             "_number_octree_levels": 3,
@@ -148,6 +160,18 @@
             "mesh_extraction_masking_options": 3,
             "mesh_extraction_fancy": true,
             "evaluation_chunk_size": 500000,
+            "micro_anisotropic": {
+                "enabled": false,
+                "points": null,
+                "residuals": null,
+                "anisotropy_matrices": null,
+                "weights": null,
+                "kernel_range": 1.0,
+                "kernel_type": "matern_5_2",
+                "nugget": 0.0,
+                "preserve_macro_points": true,
+                "strength": 1.0
+            },
             "compute_scalar": true,
             "compute_scalar_gradient": false,
             "verbose": false

--- a/test/verify_helper.py
+++ b/test/verify_helper.py
@@ -9,7 +9,7 @@ from approvaltests.core import Comparator
 import json
 from approvaltests import verify, Options
 from approvaltests.namer import NamerFactory
-from approvaltests.reporters import GenericDiffReporter, GenericDiffReporterConfig
+from approvaltests.reporters import GenericDiffReporter, GenericDiffReporterConfig, PythonNativeReporter
 
 from gempy.core.data import GeoModel
 from gempy.modules.serialization.save_load import _load_model_from_bytes, model_to_bytes
@@ -36,7 +36,9 @@ def verify_json(item, name: str):
         extra_args=["diff"]
     )
 
-    if os.environ.get("WSL_DISTRO_NAME"):
+    if os.environ.get("TEAMCITY_VERSION") or os.environ.get("CI"):
+        reporter = PythonNativeReporter()
+    elif os.environ.get("WSL_DISTRO_NAME"):
         reporter = WSLWindowsDiffReporter(config)
     else:
         reporter = LinuxDiffReporter(config)
@@ -55,6 +57,8 @@ def gempy_verify_array(item, name: str, rtol: float = 1e-5, atol: float = 1e-5, 
     )
     
     reporter.extra_args = ["diff"]
+    if os.environ.get("TEAMCITY_VERSION") or os.environ.get("CI"):
+        reporter = PythonNativeReporter()
 
     parameters: Options = NamerFactory \
         .with_parameters(name) \


### PR DESCRIPTION
# Description

Replaces the implicit-function-based `FiniteFaultData` representation with a higher-level `FiniteFault` data class (center, strike/dip radii, taper type, rotation) that lives in user-space coordinates. The coordinate transformation into engine space is now performed lazily at compute time inside a new `input_data_descriptor_from_geo_model` function, keeping the model's own `input_data_descriptor` untouched between calls.

`StructuralGroup` gains first-class finite-fault lifecycle management:
- `set_finite_fault` activates a `FiniteFault` on a fault group.
- `disable_finite_fault` / `enable_finite_fault` toggle the fault without losing its geometry (stored in `finite_fault_draft`).
- A `fault_type` property reports `INFINITE`, `FINITE`, or `DISABLED`.
- Each `StructuralGroup` now carries a stable UUID `id` generated on construction.

`FaultType` and `FiniteFault`/`TaperType` are re-exported from the top-level `gempy.data` namespace, replacing the now-removed `FiniteFaultData`.

Model serialization is extended with a `liquid_earth_meta.json` sidecar inside the zip archive that persists per-group `id` values and any `finite_fault_draft` so that disabled finite faults survive a save/load round-trip.

The transform validation in `input_data_descriptor_from_geo_model` enforces that finite faults are only used with isotropic, non-tilting model transforms, raising a descriptive `ValueError` otherwise.

Bumps the `gempy_engine` minimum requirement to `>=2026.1.1a1`.

Relates to <issue>

# Checklist
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] I have created tests which cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New tests pass locally with my changes.