### PR TITLE
[ENH] Add `MicroPointsTable`, element ownership, and versioned serialization with `micro_points.bin`

### DIFF
--- a/docs/developers_notes/features/MICRO_POINT_FRONTEND_DESIGN.md
+++ b/docs/developers_notes/features/MICRO_POINT_FRONTEND_DESIGN.md
@@ -1,0 +1,742 @@
+# Micro Point Front-End and Serialization Design
+
+Status: GemPy data model and serialization implemented; engine integration proposed
+
+This document defines how high-density micro contacts should enter GemPy, cross
+the GemPy-to-engine boundary, and be serialized. It also defines the local RBF
+correction that consumes those contacts.
+
+Where this document conflicts with `../../../../gempy_engine/MICRO_ANISOTROPIC_FIELD_DEFORMATION.md` or
+`../../../../gempy_engine/PLAN.md`, this document is authoritative. Those documents describe the
+prototype and contain assumptions that are not valid for spatially varying
+anisotropy.
+
+Implemented in the user-facing `gempy` package:
+
+- `MicroPointsTable` and its transform validation.
+- Per-`StructuralElement` ownership and `StructuralFrame` aggregation.
+- `.gempy` container format version 2 with `micro_points.bin`.
+- Backward-compatible loading of legacy version 1 archives.
+- Focused table, ownership, corruption, determinism, and round-trip tests.
+
+Implementation locations:
+
+| Concern | GemPy file |
+|---|---|
+| Authored table and validation | `gempy/core/data/micro_points.py` |
+| Element ownership | `gempy/core/data/structural_element.py` |
+| Aggregation and redistribution | `gempy/core/data/structural_frame.py` |
+| Binary section decoder | `gempy/core/data/encoders/binary_encoder.py` |
+| Binary loading context | `gempy/core/data/encoders/converters.py` |
+| Container writer and reader | `gempy/modules/serialization/save_load.py` |
+| Table tests | `test/test_core/test_micro_points.py` |
+| Archive tests | `test/test_modules/test_micro_points_serialization.py` |
+
+Not yet implemented:
+
+- Conversion into engine coordinates and `InterpolationInput`.
+- Per-stack partitioning and target/residual construction.
+- The consistent local RBF solve, gradients, and octree refinement.
+
+## 1. Purpose
+
+Micro points are dense observations used to make an existing macro geological
+model locally comply with contacts without adding every contact to the global
+cokriging system.
+
+The intended pipeline is:
+
+```text
+GemPy macro observations
+    -> macro cokriging solve
+    -> macro scalar field and gradients
+    -> per-stack micro residual solve
+    -> macro field + local micro correction
+    -> activation, octree refinement, and mesh extraction
+```
+
+The macro model remains the structural hypothesis. Micro points are a local
+compliance layer and do not replace surface points or orientations.
+
+## 2. Goals
+
+- Represent each micro point as a position, local geological frame, and local
+  anisotropic support.
+- Use the same representation in a Python front end and a 3D editor.
+- Associate every micro point with exactly one `StructuralElement`.
+- Keep authored observations separate from options and solved runtime state.
+- Preserve micro points through `gempy.save_model()` and `gempy.load_model()`.
+- Apply a correction only to the stack and interface to which a point belongs.
+- Use one mathematically consistent operator for fitting and evaluation.
+- Preserve coordinate, dtype, device, and gradient consistency.
+
+## 3. Non-Goals
+
+- Micro points do not participate in the macro cokriging matrix.
+- Solved residuals and RBF weights are not durable model input.
+- The initial engine integration will not support one micro point constraining
+  multiple interfaces.
+- The initial engine integration will not define corrections across fault
+  blocks.
+- Micro table dtype version 1 does not accept perspective transforms or
+  arbitrary projective matrices.
+
+## 4. Terminology
+
+- **Macro point:** A standard `SurfacePointsTable` or `OrientationsTable`
+  observation used by the main interpolation system.
+- **Micro point:** A dense contact observation used by the additive local
+  correction.
+- **Support transform:** A `4x4` affine transform mapping normalized local
+  support coordinates to the model's world/input coordinate system.
+- **Support scale:** The correlation lengths encoded in the linear part of a
+  support transform. It is not merely a display-gizmo scale.
+- **Local RBF:** A radial basis function centered at one micro point and
+  evaluated using that point's support transform.
+
+## 5. Front-End Data Model
+
+### 5.1 Ownership
+
+`MicroPointsTable` is owned by `StructuralElement`, in the same vein as
+`SurfacePointsTable` and `OrientationsTable`:
+
+```python
+class StructuralElement:
+    surface_points: SurfacePointsTable
+    orientations: OrientationsTable
+    micro_points: MicroPointsTable
+```
+
+This establishes the interface association without a separate mutable
+model-level relation. Moving an element between groups moves its micro points;
+removing an element removes them. Basement elements must have an empty micro
+table.
+
+`StructuralFrame` provides derived aggregate views:
+
+```text
+micro_points_copy
+number_of_micro_points_per_element
+number_of_micro_points_per_group
+```
+
+The aggregate table is needed for binary serialization and engine conversion,
+but it is not the authoritative mutable owner.
+
+The implementation intentionally uses the existing integer
+`StructuralElement.id` behavior, matching surface points and orientations. On
+save, every micro row must match its owning element's current ID. When micro
+points are present, element IDs must also be unique. Loading rejects rows whose
+IDs do not resolve to a non-basement structural element.
+
+The fallback ID remains name-derived when `_id == -1`, so renaming an element
+without updating its observation tables is an existing model-wide limitation,
+not something solved by this serialization change. A future stable UUID or
+materialized-ID migration would need to cover surface points and orientations
+at the same time. Dense surface and stack indices remain runtime values derived
+from current structural order.
+
+### 5.2 Canonical Transform
+
+For point `i`, define:
+
+```text
+x_world_h = H_world_from_support[i] @ x_support_h
+```
+
+with:
+
+```text
+H_world_from_support = [ B_i  p_i ]
+                       [ 0     1  ]
+```
+
+- `p_i` is the micro-point position.
+- The columns of `B_i` are local support axes expressed in world coordinates.
+- The lengths of those columns are the kernel correlation lengths.
+- The third local axis is the interface-normal direction.
+
+For the initial axisymmetric model:
+
+```text
+B_i = R_i @ diag(lateral_range_i, lateral_range_i, normal_range_i)
+```
+
+where `normal_range_i < lateral_range_i` in the common case. Rotation around
+the normal has no effect when both lateral ranges are equal, but retaining a
+complete frame is convenient for 3D front ends and allows future triaxial
+support.
+
+The position must not also be serialized as independent `X`, `Y`, and `Z`
+fields. The translation column is authoritative. A convenience `xyz` property
+may return `support_transforms[:, :3, 3]`.
+
+### 5.3 Scale Semantics
+
+The three support scales are physical correlation lengths in model coordinate
+units. Applying the inverse transform produces dimensionless local coordinates.
+
+This removes the ambiguous double scaling in the prototype, where
+`anisotropy_matrices` contain inverse ranges and the result is divided by a
+second `kernel_range`. The durable representation has one source of geometric
+range: the support transform.
+
+An optional global support multiplier may exist as an algorithm option, but it
+must multiply all support lengths explicitly and must be applied identically
+during fitting and evaluation.
+
+### 5.4 Implemented Table
+
+The public object is exported as `gp.data.MicroPointsTable` and provides:
+
+```python
+@dataclass
+class MicroPointsTable:
+    data: np.ndarray
+    name_id_map: dict[str, int] | None = None
+
+    @classmethod
+    def from_transforms(
+        cls,
+        support_transforms: np.ndarray,
+        names: Sequence[str] | str,
+        nugget: np.ndarray | None = None,
+        name_id_map: dict[str, int] | None = None,
+    ) -> "MicroPointsTable": ...
+
+    @classmethod
+    def initialize_empty(cls) -> "MicroPointsTable": ...
+
+    @property
+    def support_transforms(self) -> np.ndarray: ...
+
+    @property
+    def xyz(self) -> np.ndarray: ...
+```
+
+The implemented table dtype version 1 is:
+
+```python
+np.dtype([
+    ("support_transform", "<f8", (4, 4)),
+    ("element_id", "<i8"),
+    ("nugget", "<f8"),
+], align=False)
+```
+
+This has a packed row size of 144 bytes:
+
+| Field | Bytes | Meaning |
+|---|---:|---|
+| `support_transform` | 128 | Local-support-to-world affine transform |
+| `element_id` | 8 | Durable association used during flatten/load |
+| `nugget` | 8 | Diagonal regularization for this observation |
+
+Little-endian encoding is explicit. The wider element ID avoids repeating the
+`int32` limitation of the existing point tables.
+
+The per-row ID remains useful even though elements own their tables: the
+flattened binary table needs to be redistributed after loading, just as the
+existing surface-point and orientation tables are redistributed by ID.
+
+### 5.5 Authored Versus Derived State
+
+Persisted input:
+
+- Support transforms.
+- Element association.
+- Per-observation nugget.
+
+Algorithm configuration:
+
+- Enabled state.
+- Kernel family.
+- Correction strength.
+- Macro-preservation policy.
+- Solver and conditioning policy.
+- Contact-driven refinement policy.
+
+Derived runtime state:
+
+- Engine-coordinate support transforms.
+- Macro values and gradients at micro points.
+- Target interface scalar values.
+- Residuals.
+- Local RBF weights.
+- Solver diagnostics.
+
+Derived state must not be stored in `MicroAnisotropicOptions` or serialized as
+model input. It becomes stale when macro observations, transforms, structural
+grouping, faults, or interpolation settings change.
+
+## 6. Validation
+
+`MicroPointsTable` construction must validate:
+
+- Shape is exactly `(N, 4, 4)`.
+- All matrix and nugget values are finite.
+- Every last row is approximately `[0, 0, 0, 1]`.
+- The `3x3` linear block is invertible.
+- Authored support axes are orthogonal within tolerance for version 1.
+- All three authored support scales are strictly positive.
+- The authored linear block has positive determinant.
+- The condition number remains below a documented limit.
+- The number of names, nuggets, and transforms is identical.
+- Every element association resolves to a non-basement element.
+- Nugget values are nonnegative.
+
+The implementation uses:
+
+```text
+affine and orthogonality tolerance = 1e-6
+maximum condition number           = 1e12
+default nugget                     = 0.0
+```
+
+Direct construction from structured data additionally requires a
+one-dimensional array with the exact fixed dtype. `from_transforms()` converts
+input matrices to `float64`, requires shape `(N, 4, 4)`, and resolves element
+IDs from names using the same mapping mechanism as the existing observation
+tables.
+
+Micro table dtype version 1 deliberately accepts TRS support transforms, not
+shear. The combined world-to-engine transform may make the engine-space linear
+block non-orthogonal; orthogonality is therefore checked on authored transforms
+before composition, not after it.
+
+Normal validation errors must use regular exceptions or Pydantic validators,
+not `assert`, because assertions disappear under `python -O`.
+
+## 7. Coordinate Frames
+
+### 7.1 Persisted Frame
+
+Support transforms are persisted in the same world/input coordinate frame as
+surface points and orientation positions. Micro points must not influence the
+calculation of the model's global input transform; adding local compliance data
+must not rescale the macro model.
+
+### 7.2 World-to-Engine Conversion
+
+Let `E` be the complete homogeneous world-to-engine transform, including the
+grid transform around its cached pivot followed by `GeoModel.input_transform`:
+
+```text
+x_engine_h = E @ x_world_h
+```
+
+Then each support transforms exactly by composition:
+
+```text
+H_engine_from_support = E @ H_world_from_support
+```
+
+Runtime evaluation extracts:
+
+```text
+p_i = H_engine_from_support[:3, 3]
+B_i = H_engine_from_support[:3, :3]
+A_i = inverse(B_i)
+```
+
+For an engine-space query point `x`, normalized local coordinates and distance
+are:
+
+```text
+u_i(x) = A_i @ (x - p_i)
+r_i(x) = ||u_i(x)||
+```
+
+This guarantees coordinate invariance:
+
+```text
+||A_world @ (x_world - p_world)||
+    ==
+||A_engine @ (x_engine - p_engine)||
+```
+
+The conversion must use homogeneous matrix multiplication. It must not use
+component-wise `Transform.__add__` or decompose the support through
+`Transform.from_matrix()`, because those paths do not preserve general affine
+composition under rotation and nonuniform scale.
+
+## 8. Engine Boundary
+
+### 8.1 Data Placement
+
+Numerical micro observations belong in `InterpolationInput`, alongside surface
+points and orientations. They do not belong in interpolation options.
+
+Conceptually:
+
+```python
+@dataclass
+class MicroPoints:
+    support_transforms: ArrayLike  # (N, 4, 4), engine coordinates
+    surface_indices: ArrayLike     # (N,), dense global interface indices
+    nuggets: ArrayLike             # (N,)
+```
+
+`InputDataDescriptor` should carry partition metadata, preferably the number of
+micro points per surface. That supports validation and deterministic slicing by
+stack without pretending micro points are macro cokriging constraints.
+
+`MicroAnisotropicOptions` should contain policy only. The prototype fields
+`points`, `residuals`, `anisotropy_matrices`, and `weights` should not form the
+public architecture.
+
+### 8.2 Stack Isolation
+
+During stack subset construction, include only micro points associated with
+surfaces in the active stack. The resulting correction must not be added to:
+
+- Unrelated stratigraphic stacks.
+- Fault scalar fields unless fault micro correction is explicitly supported.
+- External or null-space interpolation groups unless explicitly supported.
+
+This is required because the current prototype stores one global correction in
+evaluation options and can apply it to every evaluated scalar field.
+
+## 9. Local RBF Correction
+
+### 9.1 Macro Targets and Residuals
+
+For micro point `p_i` associated with interface `s(i)`, evaluate the macro field
+and use the same canonical interface scalar value consumed by activation:
+
+```text
+y_i = c_macro[s(i)] - V_macro(p_i)
+```
+
+The canonical macro interface values must remain immutable during the micro
+pass. They must not be recomputed from surface-point samples after applying the
+micro correction.
+
+### 9.2 Consistent Basis
+
+For a kernel `k`, basis `i` evaluated at query `x` is:
+
+```text
+phi_i(x) = k(r_i(x))
+```
+
+where `r_i` is calculated from support transform `i`. Construct the fitting
+matrix by evaluating that exact basis at every constraint point:
+
+```text
+Phi[j, i] = phi_i(p_j)
+```
+
+Solve:
+
+```text
+(Phi + diag(nugget)) @ w = y
+```
+
+and evaluate:
+
+```text
+V_micro(x) = sum_i w_i * phi_i(x)
+V_final(x) = V_macro(x) + strength * V_micro(x)
+```
+
+`Phi` is generally nonsymmetric because each column uses its source point's
+support transform. The system is therefore a local RBF system, not a covariance
+matrix. Dense direct solve, GMRES, BiCGSTAB, or least squares are valid solver
+families; Conjugate Gradient is not valid for the general nonsymmetric system.
+
+A nonzero nugget deliberately relaxes exact snapping. With zero nugget and a
+nonsingular system, evaluating the fitted basis at the constraint points must
+reproduce the residual vector.
+
+### 9.3 Prototype Difference
+
+The snapping prototype solves with a symmetric pair distance based on:
+
+```text
+(A_i.T @ A_i + A_j.T @ A_j) / 2
+```
+
+but evaluates with only the source matrix `A_i`. Those operators differ when
+anisotropy varies between points. The identity-matrix round-trip test does not
+expose the mismatch.
+
+The production design uses the one-sided source basis in both fitting and
+evaluation. It makes no positive-semidefinite covariance claim.
+
+### 9.4 Gradients
+
+When scalar gradients are requested, the returned gradient must include the
+micro correction. For `u_i = A_i(x - p_i)` and `r_i = ||u_i||`:
+
+```text
+grad(r_i) = A_i.T @ u_i / r_i
+grad(phi_i) = k'(r_i) * grad(r_i)
+```
+
+The implementation must handle `r_i = 0` using the analytic kernel limit.
+
+```text
+grad(V_final) = grad(V_macro)
+              + strength * sum_i w_i * grad(phi_i)
+```
+
+Returning a corrected scalar with macro-only gradients is invalid for dual
+contouring and any gradient-based refinement or diagnostics.
+
+## 10. Model Serialization
+
+### 10.1 Implemented Container Version
+
+`gempy.save_model()` now writes `.gempy` container format version 2 in
+`gempy/modules/serialization/save_load.py`. It is a ZIP archive with this exact
+member order:
+
+```text
+model.gempy
+|-- header.json
+|-- input.bin
+|-- micro_points.bin
+|-- grid.bin
+`-- liquid_earth_meta.json
+```
+
+`header.json` contains a container manifest injected by `model_to_bytes()`:
+
+```json
+{
+  "serialization": {
+    "format": "gempy",
+    "version": 2,
+    "writer_version": "<gempy-version>",
+    "byte_order": "little"
+  }
+}
+```
+
+A missing manifest means legacy version 1. The manifest is container metadata,
+not a `GeoModel` field, and is removed before `GeoModel.model_validate()`.
+
+The reader currently accepts exactly format `"gempy"`, version `2`, and byte
+order `"little"`. It rejects unsupported values instead of attempting a
+best-effort decode.
+
+`model_to_bytes()` injects the following micro section into
+`structural_frame.binary_meta_data`:
+
+```json
+{
+  "micro_points": {
+    "dtype_version": 1,
+    "row_count": 42,
+    "byte_length": 6048
+  }
+}
+```
+
+The micro metadata is container-specific and is not emitted by a raw
+`GeoModel.model_dump_json()` call. The reader selects the fixed local dtype from
+`dtype_version`; it does not execute or trust an arbitrary dtype supplied by
+the archive.
+
+### 10.2 Relationship to Existing Binary Data
+
+The existing macro input layout remains unchanged:
+
+```text
+input.bin = SurfacePointsTable bytes + OrientationsTable bytes
+```
+
+`StructuralFrame.binary_meta_data` continues to record `sp_binary_length` and
+`ori_binary_length`. Micro rows are not appended to `input.bin`; they are stored
+in the dedicated member because:
+
+- Existing readers ignore trailing `input.bin` bytes.
+- The micro member can be length- and schema-validated independently.
+- Surface-point and orientation offsets remain backward compatible.
+- Future micro dtype versions do not need to change the macro stream.
+
+### 10.3 Save Flow
+
+1. `StructuralFrame.validate_micro_point_ownership()` checks IDs before any
+   bytes are written.
+2. `StructuralElement.micro_points` is excluded from model JSON as a
+   binary-only observation table; loading without a binary section uses an
+   independent empty-table default.
+3. `StructuralFrame.micro_points_copy` concatenates rows in structural order,
+   including a zero-row basement contribution.
+4. `model_to_bytes()` writes the packed rows to `micro_points.bin`.
+5. The writer uses `ZIP_STORED`, timestamp `1980-01-01 00:00:00`,
+   `ZipInfo.create_system = 0`, and `external_attr = 0x20` for every member.
+6. Serialization validation compares the original and loaded micro tables
+   directly, not through process-local `hash(bytes)` values.
+
+These settings, fixed JSON formatting, and fixed member order make repeated
+saves byte-for-byte deterministic without depending on a zlib implementation.
+
+### 10.4 Load Flow
+
+1. Parse `header.json`, remove the optional container manifest, and validate it
+   when present.
+2. Interpret a missing manifest as version 1 and do not consume an unversioned
+   micro member.
+3. Require `micro_points.bin` for version 2, including when it is empty.
+4. Inject micro bytes through `loading_model_from_binary()` alongside
+   `input.bin` and `grid.bin`.
+5. Construct each `StructuralElement` with its own empty micro table default.
+6. Require metadata to be an object with `dtype_version == 1`, nonnegative
+   integer `row_count`, and nonnegative integer `byte_length`.
+7. Require `byte_length == len(micro_points.bin)`, divisibility by 144, and
+   `row_count * 144 == byte_length` before decoding.
+8. Decode using the fixed little-endian dtype and copy the `np.frombuffer()`
+   result so loaded tables remain writable.
+9. Validate every transform and nugget through `MicroPointsTable`.
+10. Reject unknown element IDs and ambiguous duplicate element IDs.
+11. Redistribute rows to element-owned tables by `element_id`.
+
+Loading an existing version 1 archive produces independent empty micro tables,
+so old model files remain loadable. A version 2 archive missing
+`micro_points.bin` is invalid and raises a clear error.
+
+### 10.5 What Is Not Serialized
+
+Do not serialize:
+
+- Engine-coordinate transforms.
+- Inverse `3x3` anisotropy operators.
+- Macro scalar samples or gradients.
+- Target scalar values.
+- Residuals.
+- RBF weights.
+- Solver factorizations or condition estimates.
+
+These values depend on the current macro model and are recomputed. If solved
+state is cached in the future, it must be a disposable cache keyed by a strong
+fingerprint over all inputs and options, not authoritative model data.
+
+## 11. Test Status
+
+### 11.1 Implemented Table Tests
+
+The table tests are implemented in:
+
+```text
+gempy/test/test_core/test_micro_points.py
+```
+
+Coverage includes:
+
+- Exact dtype names, byte order, offsets, and 144-byte row size.
+- Construction, empty defaults, writable `xyz`, and element filtering.
+- Independent empty tables for separate structural elements.
+- Invalid input shapes and multidimensional structured arrays.
+- Invalid affine rows, nonfinite values, zero scales, shear, reflections, and
+  excessive condition numbers.
+- Invalid nugget values and mismatched input lengths.
+
+### 11.2 Implemented Serialization Tests
+
+Serialization tests are implemented in:
+
+```text
+gempy/test/test_modules/test_micro_points_serialization.py
+```
+
+Coverage includes:
+
+- Public `save_model()` and `load_model()` round trips.
+- Exact matrix, ID, and nugget preservation for multiple elements.
+- Structural-order aggregation and per-element/per-group counts.
+- Redistribution of shuffled binary rows by element ID.
+- Loading the existing version 1 `Greenstone.gempy` fixture with empty tables.
+- Exact archive member order, `ZIP_STORED`, and platform metadata.
+- Byte-for-byte deterministic repeated saves.
+- Rejection of missing members, truncated rows, row-count mismatch,
+  unsupported dtype and container versions, unknown IDs, duplicate element
+  IDs, and ownership mismatches.
+- Verification that support matrices remain outside `header.json` and loaded
+  arrays remain writable.
+
+### 11.3 Remaining Persistence Tests
+
+- Moving and removing elements while preserving ownership semantics.
+- Explicit basement-association rejection.
+- Unsupported manifest format and byte-order values.
+- Saving a computed model and proving no derived micro runtime state appears in
+  the archive once engine integration exists.
+
+### 11.4 Required Coordinate Conversion Tests
+
+- Identity conversion.
+- Translation, rotation, and isotropic model scaling.
+- Nonuniform model scaling.
+- Grid rotation around a nonzero pivot.
+- Combined grid and input transforms.
+- Micro center conversion matches the normal point-conversion pipeline.
+- Normalized support distance is invariant between world and engine frames.
+- Source matrices are not mutated during conversion.
+
+### 11.5 Required Local RBF Tests
+
+- One-point correction.
+- Solve/evaluate round trip with different support transforms at every point.
+- All supported kernels use the same type during solve and evaluation.
+- Zero nugget reproduces residuals within solver tolerance.
+- Nonzero nugget has documented smoothing behavior.
+- `strength=0` returns the exact macro field.
+- Analytic micro gradients match finite differences.
+- Scalar output is identical whether gradients are requested or not.
+- Duplicate and nearly duplicate points fail or regularize deterministically.
+- NumPy and PyTorch preserve dtype, device, and numerical parity.
+
+### 11.6 Required Integration Tests
+
+- Micro points only modify their associated stack.
+- Points on two interfaces receive the correct target scalar values.
+- Fault and unsupported stack types reject micro correction clearly.
+- Macro-preservation policy has measurable, documented behavior.
+- Corrected gradients reach dual contouring.
+- Contact-driven octree refinement resolves isolated contacts.
+- Extracted interfaces approach contacts within the configured tolerance.
+- Plotting is opt-in and disabled in automated tests.
+
+## 12. Implementation Sequence
+
+Current implementation progress:
+
+- [x] Add and validate `MicroPointsTable` in the user-facing `gempy` package.
+- [x] Attach an empty table to every `StructuralElement` and aggregate it
+  through `StructuralFrame`.
+- [x] Introduce serialization version 2 and `micro_points.bin` with
+  compatibility tests for existing files.
+- [ ] Add GemPy APIs for adding, modifying, and deleting micro points.
+- [ ] Add the numerical micro data object to `InterpolationInput` and partition
+  metadata to `InputDataDescriptor`.
+- [ ] Compose support transforms into engine coordinates in the GemPy engine
+  factory.
+- [ ] Slice micro data per stack and derive residuals from immutable macro
+  interface values.
+- [ ] Replace the prototype solve with the consistent local RBF system.
+- [ ] Add micro gradients, backend parity, and conditioning diagnostics.
+- [ ] Add contact-driven octree refinement and mesh-level compliance tests.
+
+Each stage should leave models with no micro points behaviorally identical to
+current models.
+
+## 13. Open Decisions
+
+- Whether macro preservation uses all macro surface points, one reference point
+  per interface, or nearby weighted anchors.
+- Which nonsymmetric solver is used after the dense reference implementation.
+- Whether per-point nugget is a direct diagonal regularizer or derived from a
+  separately named uncertainty measurement.
+- Whether to add Euler/TRS convenience construction for triaxial supports;
+  complete matrices with unequal orthogonal scales are already accepted.
+- How micro correction is masked across finite-fault domains.
+- Whether the existing name-derived fallback element IDs should eventually be
+  replaced by stable UUIDs across all observation tables.
+
+These decisions do not change the core contract: a micro observation is owned
+by one structural element and persisted as a local-support-to-world `4x4`
+transform whose scale defines anisotropic kernel support.

--- a/gempy/core/data/__init__.py
+++ b/gempy/core/data/__init__.py
@@ -3,6 +3,7 @@ from .structural_frame import StructuralFrame
 from .structural_group import StructuralGroup, FaultType
 from .structural_element import StructuralElement
 from .orientations import OrientationsTable
+from .micro_points import MicroPointsTable
 from .surface_points import SurfacePointsTable
 from .grid import Grid, Topography
 from .importer_helper import ImporterHelper
@@ -27,6 +28,7 @@ from gempy_engine.core.data.geophysics_input import GeophysicsInput
 __all__ = [
     # From gempy
     'GeoModel', 'StructuralFrame', 'StructuralGroup', 'StructuralElement', 'OrientationsTable', 'SurfacePointsTable',
+    'MicroPointsTable',
     'Grid', 'Topography',
     'ImporterHelper', 'GemPyEngineConfig', 'FaultsRelationSpecialCase', 'ColorsGenerator', 'ModelValidationError',
     # From gempy engine

--- a/gempy/core/data/encoders/binary_encoder.py
+++ b/gempy/core/data/encoders/binary_encoder.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from ..surface_points import SurfacePointsTable
 from ..orientations import OrientationsTable
+from ..micro_points import MicroPointsTable
 
 
 def deserialize_input_data_tables(binary_array: bytes, name_id_map: dict, 
@@ -37,6 +38,34 @@ def deserialize_input_data_tables(binary_array: bytes, name_id_map: dict,
     surface_points_table = SurfacePointsTable(data=sp_data, name_id_map=name_id_map)
     orientations_table = OrientationsTable(data=ori_data, name_id_map=name_id_map)
     return orientations_table, surface_points_table
+
+
+def deserialize_micro_points(
+        binary_array: bytes,
+        metadata: dict,
+        name_id_map: dict[str, int],
+) -> MicroPointsTable:
+    """Deserialize and validate a versioned micro-point binary section."""
+    if not isinstance(metadata, dict):
+        raise ValueError("Micro-point binary metadata is missing")
+    if metadata.get("dtype_version") != 1:
+        raise ValueError(f"Unsupported micro-point dtype version: {metadata.get('dtype_version')}")
+
+    row_count = metadata.get("row_count")
+    byte_length = metadata.get("byte_length")
+    if not isinstance(row_count, int) or row_count < 0:
+        raise ValueError("Micro-point row_count must be a nonnegative integer")
+    if not isinstance(byte_length, int) or byte_length < 0:
+        raise ValueError("Micro-point byte_length must be a nonnegative integer")
+    if byte_length != len(binary_array):
+        raise ValueError("Micro-point binary length does not match metadata")
+    if byte_length % MicroPointsTable.dt.itemsize != 0:
+        raise ValueError("Micro-point binary length is not a whole number of rows")
+    if row_count * MicroPointsTable.dt.itemsize != byte_length:
+        raise ValueError("Micro-point row count does not match binary length")
+
+    data = np.frombuffer(binary_array, dtype=MicroPointsTable.dt).copy()
+    return MicroPointsTable(data=data, name_id_map=name_id_map)
 
 
 def deserialize_grid(binary_array:bytes, custom_grid_length: int, topography_length: int) -> tuple[np.ndarray, np.ndarray]:

--- a/gempy/core/data/encoders/converters.py
+++ b/gempy/core/data/encoders/converters.py
@@ -52,13 +52,19 @@ numpy_array_short_validator = BeforeValidator(validate_numpy_array)
 loading_model_context = ContextVar('loading_model_context', default={})
 
 @contextmanager
-def loading_model_from_binary(input_binary: bytes, grid_binary: bytes):
-    token = loading_model_context.set({
+def loading_model_from_binary(
+        input_binary: bytes,
+        grid_binary: bytes,
+        micro_points_binary: bytes | None = None,
+):
+    context = {
             'input_binary': input_binary,
-            'grid_binary': grid_binary
-    })
+            'grid_binary': grid_binary,
+    }
+    if micro_points_binary is not None:
+        context['micro_points_binary'] = micro_points_binary
+    token = loading_model_context.set(context)
     try:
         yield
     finally:
         loading_model_context.reset(token)
-

--- a/gempy/core/data/micro_points.py
+++ b/gempy/core/data/micro_points.py
@@ -1,0 +1,155 @@
+from dataclasses import dataclass, field
+from typing import Annotated, Optional, Sequence, Union
+
+import numpy as np
+from pydantic import Field
+
+from ._data_points_helpers import generate_ids_from_names
+
+
+DEFAULT_MICRO_POINT_NUGGET = 0.0
+MICRO_POINT_AFFINE_TOLERANCE = 1e-6
+MICRO_POINT_MAX_CONDITION_NUMBER = 1e12
+
+
+@dataclass
+class MicroPointsTable:
+    """Micro contacts represented by local-support-to-world transforms."""
+
+    dt = np.dtype([
+            ("support_transform", "<f8", (4, 4)),
+            ("element_id", "<i8"),
+            ("nugget", "<f8"),
+    ], align=False)
+
+    data: Annotated[np.ndarray, Field(exclude=True)] = field(
+        default_factory=lambda: np.zeros(0, dtype=MicroPointsTable.dt)
+    )
+    name_id_map: Optional[dict[str, int]] = None
+
+    def __post_init__(self):
+        if not isinstance(self.data, np.ndarray) or self.data.dtype != self.dt:
+            raise ValueError(f"Data array must have the following data type: {self.dt}")
+        if self.data.ndim != 1:
+            raise ValueError("Micro-point data must be a one-dimensional structured array")
+
+        transforms = self.support_transforms
+        nuggets = self.nugget
+        if not np.all(np.isfinite(transforms)) or not np.all(np.isfinite(nuggets)):
+            raise ValueError("Micro-point transforms and nuggets must be finite")
+        if np.any(nuggets < 0):
+            raise ValueError("Micro-point nuggets must be nonnegative")
+        if len(self) == 0:
+            return
+
+        expected_last_row = np.array([0.0, 0.0, 0.0, 1.0])
+        if not np.allclose(
+                transforms[:, 3, :],
+                expected_last_row,
+                atol=MICRO_POINT_AFFINE_TOLERANCE,
+                rtol=0.0,
+        ):
+            raise ValueError("Micro-point transforms must have affine last row [0, 0, 0, 1]")
+
+        linear_blocks = transforms[:, :3, :3]
+        scales = np.linalg.norm(linear_blocks, axis=1)
+        if np.any(scales <= 0):
+            raise ValueError("Micro-point support scales must be positive")
+
+        normalized_axes = linear_blocks / scales[:, None, :]
+        gram_matrices = np.einsum("nji,njk->nik", normalized_axes, normalized_axes)
+        if not np.allclose(
+                gram_matrices,
+                np.eye(3),
+                atol=MICRO_POINT_AFFINE_TOLERANCE,
+                rtol=0.0,
+        ):
+            raise ValueError("Micro-point support transforms must contain orthogonal axes without shear")
+
+        determinants = np.linalg.det(linear_blocks)
+        if np.any(determinants <= 0):
+            raise ValueError("Micro-point support transforms must be right-handed and invertible")
+
+        condition_numbers = np.linalg.cond(linear_blocks)
+        if np.any(condition_numbers > MICRO_POINT_MAX_CONDITION_NUMBER):
+            raise ValueError(
+                f"Micro-point support transform condition number exceeds {MICRO_POINT_MAX_CONDITION_NUMBER:g}"
+            )
+
+    @classmethod
+    def from_transforms(
+            cls,
+            support_transforms: np.ndarray,
+            names: Union[Sequence[str], str],
+            nugget: Optional[np.ndarray] = None,
+            name_id_map: Optional[dict[str, int]] = None,
+    ) -> "MicroPointsTable":
+        transforms = np.asarray(support_transforms, dtype=np.float64)
+        if transforms.ndim != 3 or transforms.shape[1:] != (4, 4):
+            raise ValueError("support_transforms must have shape (N, 4, 4)")
+
+        n_points = len(transforms)
+        if isinstance(names, str):
+            normalized_names: Union[Sequence[str], str] = names
+        else:
+            normalized_names = list(names)
+            if len(normalized_names) != n_points:
+                raise ValueError("names and support_transforms must have the same length")
+
+        if nugget is None:
+            nuggets = np.full(n_points, DEFAULT_MICRO_POINT_NUGGET, dtype=np.float64)
+        else:
+            nuggets = np.asarray(nugget, dtype=np.float64)
+            if nuggets.ndim != 1 or len(nuggets) != n_points:
+                raise ValueError("nugget must have shape (N,)")
+
+        ids, resolved_name_id_map = generate_ids_from_names(
+            name_id_map,
+            normalized_names,
+            np.empty(n_points),
+        )
+        if len(ids) != n_points:
+            raise ValueError("names and support_transforms must have the same length")
+
+        data = np.zeros(n_points, dtype=cls.dt)
+        data["support_transform"] = transforms
+        data["element_id"] = ids
+        data["nugget"] = nuggets
+        return cls(data=data, name_id_map=resolved_name_id_map)
+
+    @classmethod
+    def initialize_empty(cls) -> "MicroPointsTable":
+        return cls(data=np.zeros(0, dtype=cls.dt), name_id_map={})
+
+    @property
+    def support_transforms(self) -> np.ndarray:
+        return self.data["support_transform"]
+
+    @property
+    def xyz(self) -> np.ndarray:
+        return self.support_transforms[:, :3, 3]
+
+    @property
+    def ids(self) -> np.ndarray:
+        return self.data["element_id"]
+
+    @property
+    def nugget(self) -> np.ndarray:
+        return self.data["nugget"]
+
+    def get_micro_points_by_name(self, name: str) -> "MicroPointsTable":
+        if self.name_id_map is None:
+            raise ValueError("name_id_map is not set")
+        return self.get_micro_points_by_id(self.name_id_map[name])
+
+    def get_micro_points_by_id(self, element_id: int) -> "MicroPointsTable":
+        return MicroPointsTable(
+            data=self.data[self.ids == element_id],
+            name_id_map=self.name_id_map,
+        )
+
+    def get_micro_points_by_id_groups(self) -> list["MicroPointsTable"]:
+        return [self.get_micro_points_by_id(element_id) for element_id in np.unique(self.ids)]
+
+    def __len__(self) -> int:
+        return len(self.data)

--- a/gempy/core/data/structural_element.py
+++ b/gempy/core/data/structural_element.py
@@ -1,11 +1,12 @@
 ﻿import re
 from dataclasses import dataclass, field
 from pydantic import Field
-from typing import Optional
+from typing import Annotated, Optional
 
 import numpy as np
 
 from .orientations import OrientationsTable
+from .micro_points import MicroPointsTable
 from .surface_points import SurfacePointsTable
 
 """
@@ -27,6 +28,9 @@ class StructuralElement:
     _color: str  #: The color of the structural element in hexadecimal format.
     surface_points: SurfacePointsTable  #: The points on the surface of the structural element.
     orientations: OrientationsTable  #: The orientations of the structural element.
+    micro_points: Annotated[MicroPointsTable, Field(exclude=True)] = field(
+        default_factory=MicroPointsTable.initialize_empty
+    )
 
     # Output
     # ? Should we extract this to a separate class?
@@ -37,11 +41,13 @@ class StructuralElement:
     _id: int = -1
     
     def __init__(self, name: str, surface_points: SurfacePointsTable, orientations: OrientationsTable,
-                 id: Optional[int] = -1, is_active: Optional[bool] = True, color: Optional[str] = None):
+                 id: Optional[int] = -1, is_active: Optional[bool] = True, color: Optional[str] = None,
+                 micro_points: Optional[MicroPointsTable] = None):
         self.name = name
         
         self.surface_points = surface_points
         self.orientations = orientations
+        self.micro_points = MicroPointsTable.initialize_empty() if micro_points is None else micro_points
         
         self.is_active = is_active
         self.color = color
@@ -85,6 +91,10 @@ class StructuralElement:
     @property
     def number_of_orientations(self) -> int:
         return len(self.orientations)
+
+    @property
+    def number_of_micro_points(self) -> int:
+        return len(self.micro_points)
 
     @property
     def color(self):

--- a/gempy/core/data/structural_frame.py
+++ b/gempy/core/data/structural_frame.py
@@ -12,8 +12,9 @@ from gempy_engine.core.data.input_data_descriptor import InputDataDescriptor
 from gempy_engine.core.data.kernel_classes.faults import FaultsData
 from gempy_engine.core.data.stack_relation_type import StackRelationType
 
-from .encoders.binary_encoder import deserialize_input_data_tables
+from .encoders.binary_encoder import deserialize_input_data_tables, deserialize_micro_points
 from .encoders.converters import loading_model_context
+from .micro_points import MicroPointsTable
 from .orientations import OrientationsTable
 from .structural_element import StructuralElement
 from .structural_group import StructuralGroup, FaultsRelationSpecialCase
@@ -357,6 +358,19 @@ class StructuralFrame:
         return np.array([group.number_of_orientations for group in self.structural_groups])
 
     @property
+    def number_of_micro_points_per_element(self) -> np.ndarray:
+        """Returns the number of micro points for each element, including basement."""
+        return np.array([element.number_of_micro_points for element in self.structural_elements])
+
+    @property
+    def number_of_micro_points_per_group(self) -> np.ndarray:
+        """Returns the number of micro points for each structural group."""
+        return np.array([
+                sum(element.number_of_micro_points for element in group.elements)
+                for group in self.structural_groups
+        ])
+
+    @property
     def number_of_elements_per_group(self) -> np.ndarray:
         """Returns an array with the number of elements for each structural group."""
         return np.array([group.number_of_elements for group in self.structural_groups])
@@ -419,6 +433,43 @@ class StructuralFrame:
         """Distributes the modified orientations back to the structural elements."""
         for element in self.structural_elements:
             element.orientations.data = modified_orientations.get_orientations_by_id(element.id).data
+
+    @property
+    def micro_points_copy(self) -> MicroPointsTable:
+        """Returns a copy of all micro points in structural order."""
+        all_data = np.concatenate([element.micro_points.data for element in self.structural_elements])
+        return MicroPointsTable(data=all_data.copy(), name_id_map=self.element_name_id_map)
+
+    @property
+    def micro_points(self):
+        raise AttributeError("This property can only be set, not read. Access `micro_points_copy` or an element table.")
+
+    @micro_points.setter
+    def micro_points(self, modified_micro_points: MicroPointsTable) -> None:
+        elements = [element for group in self.structural_groups for element in group.elements]
+        element_ids = [element.id for element in elements]
+        if len(set(element_ids)) != len(element_ids) and len(modified_micro_points) > 0:
+            raise ValueError("Structural element IDs must be unique when micro points are present")
+
+        unknown_ids = set(modified_micro_points.ids.tolist()) - set(element_ids)
+        if unknown_ids:
+            raise ValueError(f"Micro points reference unknown structural element IDs: {sorted(unknown_ids)}")
+
+        for element in elements:
+            element.micro_points = modified_micro_points.get_micro_points_by_id(element.id)
+
+    def validate_micro_point_ownership(self) -> None:
+        """Validate flattened micro-point associations before serialization."""
+        elements = [element for group in self.structural_groups for element in group.elements]
+        if not any(element.number_of_micro_points for element in elements):
+            return
+
+        element_ids = [element.id for element in elements]
+        if len(set(element_ids)) != len(element_ids):
+            raise ValueError("Structural element IDs must be unique when micro points are present")
+        for element in elements:
+            if np.any(element.micro_points.ids != element.id):
+                raise ValueError(f"Micro points on element '{element.name}' have a mismatched element ID")
 
     @property
     def input_tables_binary(self):
@@ -539,6 +590,13 @@ class StructuralFrame:
                     sp_binary_length_=metadata["sp_binary_length"],
                     ori_binary_length_=metadata["ori_binary_length"]
                 )
+
+                if 'micro_points_binary' in context:
+                    instance.micro_points = deserialize_micro_points(
+                        binary_array=context['micro_points_binary'],
+                        metadata=metadata.get('micro_points'),
+                        name_id_map=instance.element_name_id_map,
+                    )
 
                 return instance
             case _:

--- a/gempy/modules/serialization/save_load.py
+++ b/gempy/modules/serialization/save_load.py
@@ -13,6 +13,15 @@ from ...optional_dependencies import require_zlib
 import pathlib
 import os
 
+import numpy as np
+
+from ..._version import __version__
+
+
+SERIALIZATION_FORMAT = "gempy"
+SERIALIZATION_VERSION = 2
+SERIALIZATION_BYTE_ORDER = "little"
+
 
 def save_model(model: GeoModel, path: str | None = None, validate_serialization: bool = True):
     """
@@ -137,13 +146,29 @@ def load_model(path: str) -> GeoModel:
 
 
 def model_to_bytes(model: GeoModel) -> bytes:
+    model.structural_frame.validate_micro_point_ownership()
     with model.structural_frame.serialized_fault_relations():
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="Pydantic serializer warnings")
-            header_json = model.model_dump_json(by_alias=True, indent=4)
+            header = json.loads(model.model_dump_json(by_alias=True, indent=4))
+
+    header["serialization"] = {
+            "format"        : SERIALIZATION_FORMAT,
+            "version"       : SERIALIZATION_VERSION,
+            "writer_version": __version__,
+            "byte_order"    : SERIALIZATION_BYTE_ORDER,
+    }
+    micro_points = model.structural_frame.micro_points_copy
+    header["structural_frame"]["binary_meta_data"]["micro_points"] = {
+            "dtype_version": 1,
+            "row_count"   : len(micro_points),
+            "byte_length" : micro_points.data.nbytes,
+    }
+    header_json = json.dumps(header, indent=4)
 
     # 2) Raw binary chunks (no additional zlib.compress here)
     input_raw = model.structural_frame.input_tables_binary
+    micro_points_raw = micro_points.data.tobytes(order="C")
     grid_raw = model.grid.grid_binary
 
     # 3) Pack into a ZIP archive in a fixed order:
@@ -157,11 +182,14 @@ def model_to_bytes(model: GeoModel) -> bytes:
         # Force a fixed timestamp (1980-01-01) so the file headers don't vary
         def make_info(name):
             zi = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
-            zi.external_attr = 0  # clear OS-specific file permissions
+            zi.create_system = 0
+            zi.external_attr = 0x20
+            zi.compress_type = zipfile.ZIP_STORED
             return zi
 
         zf.writestr(make_info("header.json"), header_json)
         zf.writestr(make_info("input.bin"), input_raw)
+        zf.writestr(make_info("micro_points.bin"), micro_points_raw)
         zf.writestr(make_info("grid.bin"), grid_raw)
         zf.writestr(make_info("liquid_earth_meta.json"), _liquid_earth_meta_json(model))
 
@@ -174,21 +202,44 @@ def _load_model_from_bytes(data: bytes) -> GeoModel:
     buf = io.BytesIO(data)
     with zipfile.ZipFile(buf, "r") as zf:
         header_json = zf.read("header.json").decode("utf-8")
+        header_dict = json.loads(header_json)
+        serialization = header_dict.pop("serialization", None)
+
+        if serialization is None:
+            serialization_version = 1
+        else:
+            if not isinstance(serialization, dict):
+                raise ValueError("Serialization manifest must be an object")
+            if serialization.get("format") != SERIALIZATION_FORMAT:
+                raise ValueError(f"Unsupported serialization format: {serialization.get('format')}")
+            serialization_version = serialization.get("version")
+            if serialization_version != SERIALIZATION_VERSION:
+                raise ValueError(f"Unsupported serialization version: {serialization_version}")
+            if serialization.get("byte_order") != SERIALIZATION_BYTE_ORDER:
+                raise ValueError(f"Unsupported serialization byte order: {serialization.get('byte_order')}")
+
         input_raw = zf.read("input.bin")
+        if serialization_version == SERIALIZATION_VERSION:
+            try:
+                micro_points_raw = zf.read("micro_points.bin")
+            except KeyError as error:
+                raise ValueError("Version 2 archive is missing micro_points.bin") from error
+        else:
+            micro_points_raw = None
         grid_raw = zf.read("grid.bin")
         try:
             liquid_earth_meta = json.loads(zf.read("liquid_earth_meta.json").decode("utf-8"))
         except KeyError:
             liquid_earth_meta = None
 
-    header_dict = json.loads(header_json)
     pending = StructuralFrame._extract_and_clear_fault_relation_names(
         header_dict.get('structural_frame', {}).get('structural_groups', [])
     )
 
     with loading_model_from_binary(
             input_binary=input_raw,
-            grid_binary=grid_raw
+            grid_binary=grid_raw,
+            micro_points_binary=micro_points_raw,
     ):
         model = GeoModel.model_validate(header_dict)
 
@@ -266,12 +317,23 @@ def _to_binary(header_json, body_input, body_grid) -> bytes:
 
 
 def _validate_serialization(original_model, model_deserialized):
-    a = hash(original_model.structural_frame.surface_points_copy.data.tobytes())
-    b = hash(model_deserialized.structural_frame.surface_points_copy.data.tobytes())
-    o_a = hash(original_model.structural_frame.orientations_copy.data.tobytes())
-    o_b = hash(model_deserialized.structural_frame.orientations_copy.data.tobytes())
-    assert a == b, "Hashes for surface points are not equal"
-    assert o_a == o_b, "Hashes for orientations are not equal"
+    np.testing.assert_array_equal(
+        original_model.structural_frame.surface_points_copy.data,
+        model_deserialized.structural_frame.surface_points_copy.data,
+    )
+    np.testing.assert_array_equal(
+        original_model.structural_frame.orientations_copy.data,
+        model_deserialized.structural_frame.orientations_copy.data,
+    )
+    np.testing.assert_array_equal(
+        original_model.structural_frame.micro_points_copy.data,
+        model_deserialized.structural_frame.micro_points_copy.data,
+    )
+    for original_element, loaded_element in zip(
+            original_model.structural_frame.structural_elements,
+            model_deserialized.structural_frame.structural_elements,
+    ):
+        np.testing.assert_array_equal(original_element.micro_points.data, loaded_element.micro_points.data)
     original_model___str__ = re.sub(r'\s+', ' ', original_model.__str__())
     deserialized___str__ = re.sub(r'\s+', ' ', model_deserialized.__str__())
     if original_model___str__ != deserialized___str__:

--- a/test/test_core/test_micro_points.py
+++ b/test/test_core/test_micro_points.py
@@ -1,0 +1,124 @@
+import numpy as np
+import pytest
+
+import gempy as gp
+
+
+def _support_transform(
+        translation=(0.0, 0.0, 0.0),
+        scales=(2.0, 2.0, 0.25),
+) -> np.ndarray:
+    transform = np.eye(4)
+    transform[:3, :3] = np.diag(scales)
+    transform[:3, 3] = translation
+    return transform
+
+
+def test_micro_points_table_layout_and_views():
+    transforms = np.stack([
+            _support_transform(translation=(1.0, 2.0, 3.0)),
+            _support_transform(translation=(4.0, 5.0, 6.0), scales=(3.0, 1.5, 0.5)),
+    ])
+    table = gp.data.MicroPointsTable.from_transforms(
+        support_transforms=transforms,
+        names="layer",
+        nugget=np.array([0.0, 0.1]),
+    )
+
+    assert table.data.dtype.names == ("support_transform", "element_id", "nugget")
+    assert table.data.dtype.fields["support_transform"][1] == 0
+    assert table.data.dtype.fields["element_id"][1] == 128
+    assert table.data.dtype.fields["nugget"][1] == 136
+    assert table.data.dtype.itemsize == 144
+    assert table.data.dtype.descr == [
+            ("support_transform", "<f8", (4, 4)),
+            ("element_id", "<i8"),
+            ("nugget", "<f8"),
+    ]
+    np.testing.assert_array_equal(table.support_transforms, transforms)
+    np.testing.assert_array_equal(table.xyz, transforms[:, :3, 3])
+    np.testing.assert_array_equal(table.nugget, [0.0, 0.1])
+
+    table.xyz[0] = [7.0, 8.0, 9.0]
+    np.testing.assert_array_equal(table.support_transforms[0, :3, 3], [7.0, 8.0, 9.0])
+
+
+def test_micro_points_table_filters_by_element():
+    transforms = np.stack([_support_transform(), _support_transform(translation=(1.0, 0.0, 0.0))])
+    table = gp.data.MicroPointsTable.from_transforms(
+        support_transforms=transforms,
+        names=["a", "b"],
+        name_id_map={"a": 10, "b": 20},
+    )
+
+    selected = table.get_micro_points_by_name("b")
+    assert len(selected) == 1
+    np.testing.assert_array_equal(selected.ids, [20])
+    np.testing.assert_array_equal(selected.xyz, [[1.0, 0.0, 0.0]])
+
+
+def test_structural_elements_have_independent_empty_micro_tables():
+    empty_surface_points = gp.data.SurfacePointsTable.initialize_empty()
+    empty_orientations = gp.data.OrientationsTable.initialize_empty()
+    element_a = gp.data.StructuralElement(
+        name="a",
+        surface_points=empty_surface_points,
+        orientations=empty_orientations,
+        color="#111111",
+    )
+    element_b = gp.data.StructuralElement(
+        name="b",
+        surface_points=gp.data.SurfacePointsTable.initialize_empty(),
+        orientations=gp.data.OrientationsTable.initialize_empty(),
+        color="#222222",
+    )
+
+    assert element_a.micro_points is not element_b.micro_points
+    assert len(element_a.micro_points) == len(element_b.micro_points) == 0
+
+
+@pytest.mark.parametrize(
+    "mutate, error",
+    [
+            (lambda value: value.__setitem__((0, 3, 3), 2.0), "affine last row"),
+            (lambda value: value.__setitem__((0, 0, 0), 0.0), "support scales"),
+            (lambda value: value.__setitem__((0, 0, 1), 0.5), "orthogonal axes"),
+            (lambda value: value.__setitem__((0, 0, 0), -1.0), "right-handed"),
+            (lambda value: value.__setitem__((0, 0, 0), np.nan), "must be finite"),
+    ],
+)
+def test_micro_points_table_rejects_invalid_transforms(mutate, error):
+    transforms = np.stack([_support_transform(scales=(1.0, 1.0, 1.0))])
+    mutate(transforms)
+
+    with pytest.raises(ValueError, match=error):
+        gp.data.MicroPointsTable.from_transforms(transforms, names="layer")
+
+
+def test_micro_points_table_rejects_invalid_input_shapes_and_nuggets():
+    with pytest.raises(ValueError, match="shape"):
+        gp.data.MicroPointsTable.from_transforms(np.eye(4), names="layer")
+
+    transforms = np.stack([_support_transform(), _support_transform()])
+    with pytest.raises(ValueError, match="same length"):
+        gp.data.MicroPointsTable.from_transforms(transforms, names=["layer"])
+    with pytest.raises(ValueError, match="shape"):
+        gp.data.MicroPointsTable.from_transforms(transforms, names="layer", nugget=np.array([0.0]))
+    with pytest.raises(ValueError, match="nonnegative"):
+        gp.data.MicroPointsTable.from_transforms(
+            transforms,
+            names="layer",
+            nugget=np.array([0.0, -1.0]),
+        )
+
+
+def test_micro_points_table_rejects_multidimensional_structured_data():
+    data = np.zeros((0, 2), dtype=gp.data.MicroPointsTable.dt)
+    with pytest.raises(ValueError, match="one-dimensional"):
+        gp.data.MicroPointsTable(data=data)
+
+
+def test_micro_points_table_rejects_ill_conditioned_support():
+    transforms = np.stack([_support_transform(scales=(1.0, 1.0, 1e-13))])
+    with pytest.raises(ValueError, match="condition number"):
+        gp.data.MicroPointsTable.from_transforms(transforms, names="layer")

--- a/test/test_modules/test_micro_points_serialization.py
+++ b/test/test_modules/test_micro_points_serialization.py
@@ -1,0 +1,222 @@
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import gempy as gp
+from gempy.core.data.enumerators import ExampleModel
+from gempy.modules.serialization.save_load import _load_model_from_bytes, model_to_bytes
+
+
+def _support_transform(translation, scales) -> np.ndarray:
+    transform = np.eye(4)
+    transform[:3, :3] = np.diag(scales)
+    transform[:3, 3] = translation
+    return transform
+
+
+def _model_with_micro_points():
+    model = gp.generate_example_model(ExampleModel.HORIZONTAL_STRAT, compute_model=False)
+    elements = [element for group in model.structural_frame.structural_groups for element in group.elements]
+    name_id_map = model.structural_frame.element_name_id_map
+
+    elements[0].micro_points = gp.data.MicroPointsTable.from_transforms(
+        support_transforms=np.stack([
+                _support_transform((1.0, 2.0, 3.0), (5.0, 5.0, 0.5)),
+                _support_transform((4.0, 5.0, 6.0), (4.0, 4.0, 0.25)),
+        ]),
+        names=elements[0].name,
+        nugget=np.array([0.0, 0.1]),
+        name_id_map=name_id_map,
+    )
+    elements[1].micro_points = gp.data.MicroPointsTable.from_transforms(
+        support_transforms=np.stack([
+                _support_transform((7.0, 8.0, 9.0), (3.0, 3.0, 0.2)),
+        ]),
+        names=elements[1].name,
+        name_id_map=name_id_map,
+    )
+    return model
+
+
+def _rewrite_archive(data: bytes, replacements=None, removed=()) -> bytes:
+    replacements = replacements or {}
+    source = io.BytesIO(data)
+    target = io.BytesIO()
+    with zipfile.ZipFile(source, "r") as input_zip, zipfile.ZipFile(target, "w") as output_zip:
+        for info in input_zip.infolist():
+            if info.filename in removed:
+                continue
+            value = replacements.get(info.filename, input_zip.read(info.filename))
+            output_zip.writestr(info.filename, value, compress_type=zipfile.ZIP_STORED)
+    return target.getvalue()
+
+
+def test_micro_points_round_trip_and_archive_layout():
+    model = _model_with_micro_points()
+    serialized = model_to_bytes(model)
+    restored = _load_model_from_bytes(serialized)
+
+    original_elements = [element for group in model.structural_frame.structural_groups for element in group.elements]
+    restored_elements = [element for group in restored.structural_frame.structural_groups for element in group.elements]
+    for original, loaded in zip(original_elements, restored_elements):
+        np.testing.assert_array_equal(original.micro_points.data, loaded.micro_points.data)
+        assert loaded.micro_points.data.flags.writeable
+
+    with zipfile.ZipFile(io.BytesIO(serialized), "r") as archive:
+        assert archive.namelist() == [
+                "header.json",
+                "input.bin",
+                "micro_points.bin",
+                "grid.bin",
+                "liquid_earth_meta.json",
+        ]
+        assert all(info.compress_type == zipfile.ZIP_STORED for info in archive.infolist())
+        assert all(info.create_system == 0 for info in archive.infolist())
+        assert all(info.external_attr == 0x20 for info in archive.infolist())
+        header = json.loads(archive.read("header.json"))
+        assert header["serialization"]["version"] == 2
+        assert header["structural_frame"]["binary_meta_data"]["micro_points"] == {
+                "dtype_version": 1,
+                "row_count"   : 3,
+                "byte_length" : 3 * gp.data.MicroPointsTable.dt.itemsize,
+        }
+        assert "support_transform" not in archive.read("header.json").decode("utf-8")
+
+
+def test_structural_frame_aggregates_micro_points_in_element_order():
+    model = _model_with_micro_points()
+
+    np.testing.assert_array_equal(model.structural_frame.number_of_micro_points_per_element, [2, 1, 0])
+    np.testing.assert_array_equal(model.structural_frame.number_of_micro_points_per_group, [3])
+    np.testing.assert_array_equal(
+        model.structural_frame.micro_points_copy.xyz,
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    )
+
+
+def test_public_save_and_load_model_round_trip(tmp_path):
+    model = _model_with_micro_points()
+    path = tmp_path / "micro-points.gempy"
+
+    gp.save_model(model, path=str(path), validate_serialization=True)
+    restored = gp.load_model(str(path))
+
+    np.testing.assert_array_equal(
+        model.structural_frame.micro_points_copy.data,
+        restored.structural_frame.micro_points_copy.data,
+    )
+
+
+def test_micro_points_serialization_is_deterministic():
+    model = _model_with_micro_points()
+    assert model_to_bytes(model) == model_to_bytes(model)
+
+
+def test_micro_points_are_redistributed_by_element_id():
+    model = _model_with_micro_points()
+    serialized = model_to_bytes(model)
+    with zipfile.ZipFile(io.BytesIO(serialized), "r") as archive:
+        rows = np.frombuffer(
+            archive.read("micro_points.bin"),
+            dtype=gp.data.MicroPointsTable.dt,
+        ).copy()[::-1]
+
+    restored = _load_model_from_bytes(
+        _rewrite_archive(serialized, replacements={"micro_points.bin": rows.tobytes()})
+    )
+    for element in [element for group in restored.structural_frame.structural_groups for element in group.elements]:
+        assert np.all(element.micro_points.ids == element.id)
+
+
+def test_legacy_archive_loads_with_empty_micro_tables():
+    archive_path = Path(__file__).parents[2] / "examples/data/gempy_models/Greenstone.gempy"
+    restored = _load_model_from_bytes(archive_path.read_bytes())
+    assert all(
+        len(element.micro_points) == 0
+        for group in restored.structural_frame.structural_groups
+        for element in group.elements
+    )
+
+
+def test_version_two_requires_micro_points_member():
+    serialized = model_to_bytes(_model_with_micro_points())
+    malformed = _rewrite_archive(serialized, removed={"micro_points.bin"})
+    with pytest.raises(ValueError, match="missing micro_points.bin"):
+        _load_model_from_bytes(malformed)
+
+
+def test_micro_points_binary_length_is_validated():
+    serialized = model_to_bytes(_model_with_micro_points())
+    with zipfile.ZipFile(io.BytesIO(serialized), "r") as archive:
+        truncated = archive.read("micro_points.bin")[:-1]
+    malformed = _rewrite_archive(serialized, replacements={"micro_points.bin": truncated})
+    with pytest.raises(ValueError, match="binary length"):
+        _load_model_from_bytes(malformed)
+
+
+@pytest.mark.parametrize(
+    "metadata_key, value, error",
+    [
+            ("row_count", 4, "row count"),
+            ("dtype_version", 999, "dtype version"),
+    ],
+)
+def test_micro_points_binary_metadata_is_validated(metadata_key, value, error):
+    serialized = model_to_bytes(_model_with_micro_points())
+    with zipfile.ZipFile(io.BytesIO(serialized), "r") as archive:
+        header = json.loads(archive.read("header.json"))
+    header["structural_frame"]["binary_meta_data"]["micro_points"][metadata_key] = value
+    malformed = _rewrite_archive(
+        serialized,
+        replacements={"header.json": json.dumps(header, indent=4)},
+    )
+    with pytest.raises(ValueError, match=error):
+        _load_model_from_bytes(malformed)
+
+
+def test_unknown_micro_point_element_id_is_rejected():
+    serialized = model_to_bytes(_model_with_micro_points())
+    with zipfile.ZipFile(io.BytesIO(serialized), "r") as archive:
+        rows = np.frombuffer(
+            archive.read("micro_points.bin"),
+            dtype=gp.data.MicroPointsTable.dt,
+        ).copy()
+    rows[0]["element_id"] = np.iinfo(np.int64).max
+    malformed = _rewrite_archive(serialized, replacements={"micro_points.bin": rows.tobytes()})
+    with pytest.raises(ValueError, match="unknown structural element IDs"):
+        _load_model_from_bytes(malformed)
+
+
+def test_mismatched_element_ownership_is_rejected_before_save():
+    model = _model_with_micro_points()
+    element = model.structural_frame.structural_groups[0].elements[0]
+    element.micro_points.data["element_id"] = np.iinfo(np.int64).max
+
+    with pytest.raises(ValueError, match="mismatched element ID"):
+        model_to_bytes(model)
+
+
+def test_duplicate_structural_element_ids_are_rejected_when_micro_points_exist():
+    model = _model_with_micro_points()
+    elements = model.structural_frame.structural_groups[0].elements
+    elements[1]._id = elements[0].id
+
+    with pytest.raises(ValueError, match="must be unique"):
+        model_to_bytes(model)
+
+
+def test_unsupported_serialization_version_is_rejected():
+    serialized = model_to_bytes(_model_with_micro_points())
+    with zipfile.ZipFile(io.BytesIO(serialized), "r") as archive:
+        header = json.loads(archive.read("header.json"))
+    header["serialization"]["version"] = 999
+    malformed = _rewrite_archive(
+        serialized,
+        replacements={"header.json": json.dumps(header, indent=4)},
+    )
+    with pytest.raises(ValueError, match="Unsupported serialization version"):
+        _load_model_from_bytes(malformed)


### PR DESCRIPTION
# Description

Introduces `MicroPointsTable`, a new observation table for high-density micro contacts that locally constrain an existing macro geological model without participating in the global cokriging system. Each micro point is represented as a 4×4 affine support transform encoding position, orientation, and anisotropic correlation lengths in world coordinates, along with a per-observation nugget and a durable structural element association.

`MicroPointsTable` is owned by `StructuralElement` alongside `SurfacePointsTable` and `OrientationsTable`. `StructuralFrame` exposes aggregate views (`micro_points_copy`, `number_of_micro_points_per_element`, `number_of_micro_points_per_group`) and a write-only setter that redistributes a flattened table back to element-owned tables by element ID.

The `.gempy` container format is advanced to version 2. Saves now write a `micro_points.bin` member containing packed little-endian rows and inject a `serialization` manifest and `micro_points` metadata block into `header.json`. Version 1 archives load without error and produce independent empty micro tables on every element. The serialization validation path is updated to compare arrays directly rather than through process-local hash values, and archive members are written with fixed timestamp, `ZIP_STORED` compression, `create_system = 0`, and `external_attr = 0x20` to make repeated saves byte-for-byte deterministic.

A developer design document is included at `docs/developers_notes/features/MICRO_POINT_FRONTEND_DESIGN.md` covering the full intended pipeline, coordinate frame conventions, the consistent local RBF correction, serialization contract, and the remaining engine integration steps.

Not yet implemented: conversion of support transforms into engine coordinates, partitioning into `InterpolationInput`, the local RBF solve and gradient computation, and contact-driven octree refinement.

Relates to #<issue>

# Checklist
- [ ] My code uses type hinting for function and method arguments and return values.
- [ ] I have created tests which cover my code.
- [ ] The test code either 1. demonstrates at least one valuable use case (e.g. integration tests) 
or 2. verifies that outputs are as expected for given inputs (e.g. unit tests).
- [ ] New tests pass locally with my changes.